### PR TITLE
Added Network Policy for denying network peering to vnets outside the…

### DIFF
--- a/Policies/Network/peering-outside-disallowed.json
+++ b/Policies/Network/peering-outside-disallowed.json
@@ -1,0 +1,24 @@
+{
+    "properties": {
+        "mode": "All",
+        "displayName": "Vnet peering disallowed outside subscription",
+        "description": "No network peering can be associated to networks outside the current subscription.",
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
+                    },
+                    {
+                        "field": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings/remoteVirtualNetwork.id",
+                        "notcontains": "[subscription().id]"
+                    }
+                ]
+            },
+            "then": {
+                "effect": "deny"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a Network Policy that disallows vnets to initiate peering to vnets outside the subscription they are in. This is valid for a playground subscription in which you can do R&D but you don't want to connect to anything production in other subscriptions.