### PR TITLE
Add allowed app services plan SKU policy

### DIFF
--- a/Policies/App Service/allowed-appservicesplan-skus/README.md
+++ b/Policies/App Service/allowed-appservicesplan-skus/README.md
@@ -1,0 +1,28 @@
+# Allowed App Services Plans SKU
+
+This policy defines a white list of SKU that can be used when creating an App Services Plan.
+
+## Try on Portal
+
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FCommunity-Policy%2Fmaster%2FPolicies%2FApp%20Services%2Fallowed-appservicesplan-skus%2Fazurepolicy.json)
+
+## Try with PowerShell
+
+````powershell
+$definition = New-AzPolicyDefinition -Name "allowed-appservicesplan-skus" -DisplayName "Allowed Role Definitions" -description "This policy defines a white list of role definitions that can be used in IAM" -Policy 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/App%20Services/allowed-role-definitions/azurepolicy.rules.json' -Parameter 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/App%20Services/allowed-role-definitions/azurepolicy.parameters.json' -Mode All
+$definition
+$assignment = New-AzPolicyAssignment -Name <assignmentname> -Scope <scope>  -roleDefinitionIds <Approved Role Definitions> -PolicyDefinition $definition
+$assignment 
+````
+
+
+
+## Try with CLI
+
+````cli
+
+az policy definition create --name 'allowed-role-definitions' --display-name 'Allowed Role Definitions' --description 'This policy defines a white list of role deffnitions that can be used in IAM' --rules 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/App%20Services/allowed-role-definitions/azurepolicy.rules.json' --params 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/App%20Services/allowed-role-definitions/azurepolicy.parameters.json' --mode All
+
+az policy assignment create --name <assignmentname> --scope <scope> --policy "allowed-role-definitions" 
+
+````

--- a/Policies/App Service/allowed-appservicesplan-skus/azurepolicy.json
+++ b/Policies/App Service/allowed-appservicesplan-skus/azurepolicy.json
@@ -1,0 +1,73 @@
+{
+  "properties": {
+    "displayName": "Allowed App Services Plan SKUs",
+    "policyType": "Custom",
+    "mode": "all",
+    "description": "This policy enables you to specify a set of App Services Plan SKUs that your organization can deploy.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "App Service"
+    },
+    "parameters": {
+      "listOfAllowedSKUs": {
+        "type": "Array",
+        "metadata": {
+          "description": "The list of SKUs that can be specified for App Services Plan.",
+          "displayName": "Allowed SKUs",
+          "allowedValues": [
+            "F1",
+            "D1",
+            "B1",
+            "B2",
+            "B3",
+            "S1",
+            "S2",
+            "S3",
+            "P1",
+            "P2",
+            "P3",
+            "I1",
+            "I2",
+            "I3",
+            "P1v2",
+            "P2v2",
+            "P3v2",
+            "PC1",
+            "PC2",
+            "PC3",
+            "PC4",
+            "EP1",
+            "EP2",
+            "EP3",
+            "EI1",
+            "EI2",
+            "EI3",
+            "U1",
+            "U2",
+            "U3",
+            "Y1"
+          ]
+        }
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Web/serverfarms"
+          },
+          {
+            "not": {
+              "field": "Microsoft.Web/serverfarms/sku.name",
+              "in": "[parameters('listOfAllowedSKUs')]"
+            }
+          }
+        ]
+      },
+      "then": {
+        "effect": "Deny"
+      }
+    }
+  }
+}

--- a/Policies/App Service/allowed-appservicesplan-skus/azurepolicy.parameters.json
+++ b/Policies/App Service/allowed-appservicesplan-skus/azurepolicy.parameters.json
@@ -1,0 +1,42 @@
+{
+  "listOfAllowedSKUs": {
+    "type": "Array",
+    "metadata": {
+      "description": "The list of SKUs that can be specified for App Services Plan.",
+      "displayName": "Allowed SKUs",
+      "allowedValues": [
+        "F1",
+        "D1",
+        "B1",
+        "B2",
+        "B3",
+        "S1",
+        "S2",
+        "S3",
+        "P1",
+        "P2",
+        "P3",
+        "I1",
+        "I2",
+        "I3",
+        "P1v2",
+        "P2v2",
+        "P3v2",
+        "PC1",
+        "PC2",
+        "PC3",
+        "PC4",
+        "EP1",
+        "EP2",
+        "EP3",
+        "EI1",
+        "EI2",
+        "EI3",
+        "U1",
+        "U2",
+        "U3",
+        "Y1"
+      ]
+    }
+  }
+}

--- a/Policies/App Service/allowed-appservicesplan-skus/azurepolicy.rules.json
+++ b/Policies/App Service/allowed-appservicesplan-skus/azurepolicy.rules.json
@@ -1,0 +1,19 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/serverfarms"
+      },
+      {
+        "not": {
+          "field": "Microsoft.Web/serverfarms/sku.name",
+          "in": "[parameters('listOfAllowedSKUs')]"
+        }
+      }
+    ]
+  },
+  "then": {
+    "effect": "Deny"
+  }
+}


### PR DESCRIPTION
I've created this policy to restrict which App Services plans SKU can be used. It's like the one for VM SKU with the difference we don't have strongtype for App Services SKUs.
I've used the folder App Services to host my policy as it's the one used on main azure policy repository.

Thanks in advance !