### PR TITLE
fixing deny-vms-not-in-a-specific-subnet-from-being-part-of-a-backend-pool azurepolicy.rules.json

### DIFF
--- a/Policies/Network/deny-vms-not-in-a-specific-subnet-from-being-part-of-a-backend-pool/azurepolicy.rules.json
+++ b/Policies/Network/deny-vms-not-in-a-specific-subnet-from-being-part-of-a-backend-pool/azurepolicy.rules.json
@@ -1,7 +1,4 @@
 {
-    "displayName": "App Gateway can only have a VM's or VMSS on allowed subnets.",
-    "mode": "All",
-    "policyRule": {
     "if": {
         "allOf": [
             {


### PR DESCRIPTION
Extra metadata was copied in on accident which was breaking PowerShell deployments of policy.