### PR TITLE
fixing detection logic and param indent error

### DIFF
--- a/Policies/Network/append-nsg-rule/target-all-nsgs-by-region/azurepolicy.json
+++ b/Policies/Network/append-nsg-rule/target-all-nsgs-by-region/azurepolicy.json
@@ -64,14 +64,14 @@
             "metadata": {
                 "displayName": "direction",
                 "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. - Inbound or Outbound"
-            },
-            "targetRegion": {
-                "type": "String",
-                "metadata": {
-                    "displayName": "Target Region",
-                    "description": "NSGs created within this region will have this NSG rule applied to them.",
-                    "strongType": "location"
-                }
+            }
+        },
+        "targetRegion": {
+            "type": "String",
+            "metadata": {
+                "displayName": "Target Region",
+                "description": "NSGs created within this region will have this NSG rule applied to them.",
+                "strongType": "location"
             }
         }
     },
@@ -85,6 +85,84 @@
                 {
                     "field": "location",
                     "equals": "[parameters('targetRegion')]"
+                },
+                {
+                    "count": {
+                        "field": "Microsoft.Network/networkSecurityGroups/securityRules[*]",
+                        "where": {
+                            "allOf": [
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].name",
+                                    "equals": "[parameters('name')]"
+                                },
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].protocol",
+                                    "equals": "[parameters('protocol')]"
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourcePortRange'), parameters('sourcePortRange'))]",
+                                            "equals": true
+                                        },
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourcePortRanges'), parameters('sourcePortRange'))]",
+                                            "equals": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationPortRange'), parameters('destinationPortRange'))]",
+                                            "equals": true
+                                        },
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationPortRanges'), parameters('destinationPortRange'))]",
+                                            "equals": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefix'), parameters('sourceAddressPrefix'))]",
+                                            "equals": true
+                                        },
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefixes'), parameters('sourceAddressPrefix'))]",
+                                            "equals": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefix'), parameters('destinationAddressPrefix'))]",
+                                            "equals": true
+                                        },
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefixes'), parameters('destinationAddressPrefix'))]",
+                                            "equals": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].access",
+                                    "equals": "[parameters('access')]"
+                                },
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].priority",
+                                    "equals": "[parameters('priority')]"
+                                },
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].direction",
+                                    "equals": "[parameters('direction')]"
+                                }
+                            ]
+                        }
+                    },
+                    "equals": 0
                 }
             ]
         },

--- a/Policies/Network/append-nsg-rule/target-all-nsgs-by-region/azurepolicy.parameters.json
+++ b/Policies/Network/append-nsg-rule/target-all-nsgs-by-region/azurepolicy.parameters.json
@@ -60,14 +60,14 @@
         "metadata": {
             "displayName": "direction",
             "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic. - Inbound or Outbound"
-        },
-        "targetRegion": {
-            "type": "String",
-            "metadata": {
-                "displayName": "Target Region",
-                "description": "NSGs created within this region will have this NSG rule applied to them.",
-                "strongType": "location"
-            }
+        }
+    },
+    "targetRegion": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Target Region",
+            "description": "NSGs created within this region will have this NSG rule applied to them.",
+            "strongType": "location"
         }
     }
 }

--- a/Policies/Network/append-nsg-rule/target-all-nsgs-by-region/azurepolicy.rules.json
+++ b/Policies/Network/append-nsg-rule/target-all-nsgs-by-region/azurepolicy.rules.json
@@ -8,6 +8,84 @@
             {
                 "field": "location",
                 "equals": "[parameters('targetRegion')]"
+            },
+            {
+                "count": {
+                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*]",
+                    "where": {
+                        "allOf": [
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].name",
+                                "equals": "[parameters('name')]"
+                            },
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].protocol",
+                                "equals": "[parameters('protocol')]"
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourcePortRange'), parameters('sourcePortRange'))]",
+                                        "equals": true
+                                    },
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourcePortRanges'), parameters('sourcePortRange'))]",
+                                        "equals": true
+                                    }
+                                ]
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationPortRange'), parameters('destinationPortRange'))]",
+                                        "equals": true
+                                    },
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationPortRanges'), parameters('destinationPortRange'))]",
+                                        "equals": true
+                                    }
+                                ]
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefix'), parameters('sourceAddressPrefix'))]",
+                                        "equals": true
+                                    },
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefixes'), parameters('sourceAddressPrefix'))]",
+                                        "equals": true
+                                    }
+                                ]
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefix'), parameters('destinationAddressPrefix'))]",
+                                        "equals": true
+                                    },
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefixes'), parameters('destinationAddressPrefix'))]",
+                                        "equals": true
+                                    }
+                                ]
+                            },
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].access",
+                                "equals": "[parameters('access')]"
+                            },
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].priority",
+                                "equals": "[parameters('priority')]"
+                            },
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].direction",
+                                "equals": "[parameters('direction')]"
+                            }
+                        ]
+                    }
+                },
+                "equals": 0
             }
         ]
     },

--- a/Policies/Network/append-nsg-rule/target-all-nsgs/azurepolicy.json
+++ b/Policies/Network/append-nsg-rule/target-all-nsgs/azurepolicy.json
@@ -69,8 +69,90 @@
     },
     "policyRule": {
         "if": {
-            "field": "type",
-            "equals": "Microsoft.Network/networkSecurityGroups"
+            "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.Network/networkSecurityGroups"
+                },
+                {
+                    "count": {
+                        "field": "Microsoft.Network/networkSecurityGroups/securityRules[*]",
+                        "where": {
+                            "allOf": [
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].name",
+                                    "equals": "[parameters('name')]"
+                                },
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].protocol",
+                                    "equals": "[parameters('protocol')]"
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourcePortRange'), parameters('sourcePortRange'))]",
+                                            "equals": true
+                                        },
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourcePortRanges'), parameters('sourcePortRange'))]",
+                                            "equals": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationPortRange'), parameters('destinationPortRange'))]",
+                                            "equals": true
+                                        },
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationPortRanges'), parameters('destinationPortRange'))]",
+                                            "equals": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefix'), parameters('sourceAddressPrefix'))]",
+                                            "equals": true
+                                        },
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefixes'), parameters('sourceAddressPrefix'))]",
+                                            "equals": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefix'), parameters('destinationAddressPrefix'))]",
+                                            "equals": true
+                                        },
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefixes'), parameters('destinationAddressPrefix'))]",
+                                            "equals": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].access",
+                                    "equals": "[parameters('access')]"
+                                },
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].priority",
+                                    "equals": "[parameters('priority')]"
+                                },
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].direction",
+                                    "equals": "[parameters('direction')]"
+                                }
+                            ]
+                        }
+                    },
+                    "equals": 0
+                }
+            ]
         },
         "then": {
             "effect": "append",

--- a/Policies/Network/append-nsg-rule/target-all-nsgs/azurepolicy.rules.json
+++ b/Policies/Network/append-nsg-rule/target-all-nsgs/azurepolicy.rules.json
@@ -1,7 +1,89 @@
 {
     "if": {
-        "field": "type",
-        "equals": "Microsoft.Network/networkSecurityGroups"
+        "allOf": [
+            {
+                "field": "type",
+                "equals": "Microsoft.Network/networkSecurityGroups"
+            },
+            {
+                "count": {
+                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*]",
+                    "where": {
+                        "allOf": [
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].name",
+                                "equals": "[parameters('name')]"
+                            },
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].protocol",
+                                "equals": "[parameters('protocol')]"
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourcePortRange'), parameters('sourcePortRange'))]",
+                                        "equals": true
+                                    },
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourcePortRanges'), parameters('sourcePortRange'))]",
+                                        "equals": true
+                                    }
+                                ]
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationPortRange'), parameters('destinationPortRange'))]",
+                                        "equals": true
+                                    },
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationPortRanges'), parameters('destinationPortRange'))]",
+                                        "equals": true
+                                    }
+                                ]
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefix'), parameters('sourceAddressPrefix'))]",
+                                        "equals": true
+                                    },
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefixes'), parameters('sourceAddressPrefix'))]",
+                                        "equals": true
+                                    }
+                                ]
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefix'), parameters('destinationAddressPrefix'))]",
+                                        "equals": true
+                                    },
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefixes'), parameters('destinationAddressPrefix'))]",
+                                        "equals": true
+                                    }
+                                ]
+                            },
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].access",
+                                "equals": "[parameters('access')]"
+                            },
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].priority",
+                                "equals": "[parameters('priority')]"
+                            },
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].direction",
+                                "equals": "[parameters('direction')]"
+                            }
+                        ]
+                    }
+                },
+                "equals": 0
+            }
+        ]
     },
     "then": {
         "effect": "append",

--- a/Policies/Network/append-nsg-rule/target-nsg-by-suffix/azurepolicy.json
+++ b/Policies/Network/append-nsg-rule/target-nsg-by-suffix/azurepolicy.json
@@ -84,6 +84,84 @@
                 {
                     "field": "name",
                     "like": "[concat('*', parameters('targetSuffix'))]"
+                },
+                {
+                    "count": {
+                        "field": "Microsoft.Network/networkSecurityGroups/securityRules[*]",
+                        "where": {
+                            "allOf": [
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].name",
+                                    "equals": "[parameters('name')]"
+                                },
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].protocol",
+                                    "equals": "[parameters('protocol')]"
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourcePortRange'), parameters('sourcePortRange'))]",
+                                            "equals": true
+                                        },
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourcePortRanges'), parameters('sourcePortRange'))]",
+                                            "equals": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationPortRange'), parameters('destinationPortRange'))]",
+                                            "equals": true
+                                        },
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationPortRanges'), parameters('destinationPortRange'))]",
+                                            "equals": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefix'), parameters('sourceAddressPrefix'))]",
+                                            "equals": true
+                                        },
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefixes'), parameters('sourceAddressPrefix'))]",
+                                            "equals": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "anyOf": [
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefix'), parameters('destinationAddressPrefix'))]",
+                                            "equals": true
+                                        },
+                                        {
+                                            "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefixes'), parameters('destinationAddressPrefix'))]",
+                                            "equals": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].access",
+                                    "equals": "[parameters('access')]"
+                                },
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].priority",
+                                    "equals": "[parameters('priority')]"
+                                },
+                                {
+                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].direction",
+                                    "equals": "[parameters('direction')]"
+                                }
+                            ]
+                        }
+                    },
+                    "equals": 0
                 }
             ]
         },

--- a/Policies/Network/append-nsg-rule/target-nsg-by-suffix/azurepolicy.rules.json
+++ b/Policies/Network/append-nsg-rule/target-nsg-by-suffix/azurepolicy.rules.json
@@ -1,7 +1,93 @@
 {
     "if": {
-        "field": "type",
-        "equals": "Microsoft.Network/networkSecurityGroups"
+        "allOf": [
+            {
+                "field": "type",
+                "equals": "Microsoft.Network/networkSecurityGroups"
+            },
+            {
+                "field": "name",
+                "like": "[concat('*', parameters('targetSuffix'))]"
+            },
+            {
+                "count": {
+                    "field": "Microsoft.Network/networkSecurityGroups/securityRules[*]",
+                    "where": {
+                        "allOf": [
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].name",
+                                "equals": "[parameters('name')]"
+                            },
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].protocol",
+                                "equals": "[parameters('protocol')]"
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourcePortRange'), parameters('sourcePortRange'))]",
+                                        "equals": true
+                                    },
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourcePortRanges'), parameters('sourcePortRange'))]",
+                                        "equals": true
+                                    }
+                                ]
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationPortRange'), parameters('destinationPortRange'))]",
+                                        "equals": true
+                                    },
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationPortRanges'), parameters('destinationPortRange'))]",
+                                        "equals": true
+                                    }
+                                ]
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefix'), parameters('sourceAddressPrefix'))]",
+                                        "equals": true
+                                    },
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefixes'), parameters('sourceAddressPrefix'))]",
+                                        "equals": true
+                                    }
+                                ]
+                            },
+                            {
+                                "anyOf": [
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefix'), parameters('destinationAddressPrefix'))]",
+                                        "equals": true
+                                    },
+                                    {
+                                        "value": "[equals(field('Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefixes'), parameters('destinationAddressPrefix'))]",
+                                        "equals": true
+                                    }
+                                ]
+                            },
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].access",
+                                "equals": "[parameters('access')]"
+                            },
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].priority",
+                                "equals": "[parameters('priority')]"
+                            },
+                            {
+                                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].direction",
+                                "equals": "[parameters('direction')]"
+                            }
+                        ]
+                    }
+                },
+                "equals": 0
+            }
+        ]
     },
     "then": {
         "effect": "append",


### PR DESCRIPTION
Previous logic would detect additional resources beyond just the nsg. This resulted in many non-compliant results even when all resources were compliant. Logic has been corrected.