### PR TITLE
Deploy a security rule to existing network security groups.

### DIFF
--- a/Policies/Network/azurepolicy.rules.json
+++ b/Policies/Network/azurepolicy.rules.json
@@ -1,0 +1,86 @@
+{
+  "properties": {
+    "displayName": "EnforceDefaultNetworksecurityrules",
+    "policyType": "Custom",
+    "mode": "All",
+    "metadata": {
+      "category": "Network",
+      "createdBy": "4be201dd-3ee8-4b2d-908c-f363b94e9083",
+      "createdOn": "2021-05-04T16:08:34.0482694Z",
+      "updatedBy": "4be201dd-3ee8-4b2d-908c-f363b94e9083",
+      "updatedOn": "2021-05-06T13:38:10.5940069Z"
+    },
+    "parameters": {},
+    "policyRule": {
+      "if": {        
+        "field": "type",
+        "equals": "Microsoft.Network/networkSecurityGroups"
+      },
+      "then": {
+        "effect": "deployIfNotExists",
+        "details": {
+          "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+          ],
+          "existenceCondition": {
+            "allof": [
+              {
+                "field": "Microsoft.Network/networkSecurityGroups/securityRules/access",
+                "equals": "Deny"
+              },
+              {
+                "field": "Microsoft.Network/networkSecurityGroups/securityRules/direction",
+                "equals": "Inbound"
+              },
+              {
+                "field": "Microsoft.Network/networkSecurityGroups/securityRules/destinationPortRange",
+                "equals": "3389"
+              }
+            ]
+          },
+          "deployment": {
+            "properties": {
+              "mode": "incremental",
+              "parameters": {
+                "nsgName": {
+                  "value": "[field('name')]"
+                }
+              },
+              "template": {
+                "$schema": "http://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {
+                  "nsgName": {
+                    "type": "string"
+                  }
+                },
+                "resources": [
+                  {
+                    "name": "[concat(parameters('nsgName'),'/Port_3389_Deny')]",
+                    "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+                    "apiVersion": "2019-11-01",
+                    "properties": {
+                      "description": "Deny RDP",
+                      "protocol": "*",
+                      "sourcePortRange": "*",
+                      "destinationPortRange": "3389",
+                      "sourceAddressPrefix": "*",
+                      "destinationAddressPrefix": "*",
+                      "access": "Deny",
+                      "priority": 100,
+                      "direction": "Inbound"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "id": "/subscriptions/d649e5e4-fa59-4824-9b8a-3a7560b15dae/providers/Microsoft.Authorization/policyDefinitions/ae086105-03b4-475e-b2c2-f265194df801",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "name": "ae086105-03b4-475e-b2c2-f265194df801"
+}

--- a/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy-parameters.json
+++ b/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy-parameters.json
@@ -1,0 +1,21 @@
+{
+    "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "DoNotEnforce",
+          "deployIfNotExists"
+        ],
+        "defaultValue": "deployIfNotExists"
+    },
+    "priority": {
+        "type": "Integer",
+        "metadata": {
+          "displayName": "priority",
+          "description": "Priority for the Deny RDP security rule. (Example: 100)."
+        }
+    }
+}

--- a/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.json
+++ b/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.json
@@ -87,7 +87,7 @@
                 "DoNotEnforce",
                 "deployIfNotExists"
             ],
-            "defaultValue": "deployIfNotExists
+            "defaultValue": "deployIfNotExists"
        },
        "priority": {
            "type": "Integer",

--- a/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.json
+++ b/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.json
@@ -5,7 +5,7 @@
     "policyRule": {
       "if": {
         "field": "type",
-        "equals": "Microsoft.Network/networkSecurityGroups"  
+        "equals": "Microsoft.Network/networkSecurityGroups"
       },
       "then": {
         "effect": "[parameters('effect')]",
@@ -38,7 +38,7 @@
                   "value": "[field('name')]"
                 },
                 "priority": {
-                    "value": "[parameters('priority')]"
+                  "value": "[parameters('priority')]"
                 }
               },
               "template": {
@@ -49,7 +49,7 @@
                     "type": "string"
                   },
                   "priority": {
-                    "type": "Integer"
+                    "type": "int"
                   }
                 },
                 "resources": [
@@ -74,7 +74,7 @@
             }
           }
         }
-      } 
+      }      
     },
     "parameters": {
         "effect": {

--- a/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.json
+++ b/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.json
@@ -1,0 +1,75 @@
+{
+    "displayName": "Enforce network security groups to have a DENY RDP security rule.",
+    "description": "Enforce network security groups to have a DENY RDP security rule.",     
+    "mode": "All",
+    "policyRule": {
+      "if": {
+        "field": "type",
+        "equals": "Microsoft.Network/networkSecurityGroups"  
+      },
+      "then": {
+        "effect": "deployIfNotExists",
+        "details": {
+          "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+          ],
+          "existenceCondition": {
+            "allof": [
+              {
+                "field": "Microsoft.Network/networkSecurityGroups/securityRules/access",
+                "equals": "Deny"
+              },
+              {
+                "field": "Microsoft.Network/networkSecurityGroups/securityRules/direction",
+                "equals": "Inbound"
+              },
+              {
+                "field": "Microsoft.Network/networkSecurityGroups/securityRules/destinationPortRange",
+                "equals": "3389"
+              }
+            ]
+          },
+          "deployment": {
+            "properties": {
+              "mode": "incremental",
+              "parameters": {
+                "nsgName": {
+                  "value": "[field('name')]"
+                }
+              },
+              "template": {
+                "$schema": "http://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {
+                  "nsgName": {
+                    "type": "string"
+                  }
+                },
+                "resources": [
+                  {
+                    "name": "[concat(parameters('nsgName'),'/Port_3389_Deny')]",
+                    "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+                    "apiVersion": "2019-11-01",
+                    "properties": {
+                      "description": "Deny RDP",
+                      "protocol": "*",
+                      "sourcePortRange": "*",
+                      "destinationPortRange": "3389",
+                      "sourceAddressPrefix": "*",
+                      "destinationAddressPrefix": "*",
+                      "access": "Deny",
+                      "priority": 100,
+                      "direction": "Inbound"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      } 
+    },
+    "parameters": {
+    }
+}

--- a/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.json
+++ b/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.json
@@ -8,7 +8,7 @@
         "equals": "Microsoft.Network/networkSecurityGroups"  
       },
       "then": {
-        "effect": "deployIfNotExists",
+        "effect": "[parameters('effect')]",
         "details": {
           "type": "Microsoft.Network/networkSecurityGroups/securityRules",
           "roleDefinitionIds": [
@@ -36,6 +36,9 @@
               "parameters": {
                 "nsgName": {
                   "value": "[field('name')]"
+                },
+                "priority": {
+                    "value": "[parameters('priority')]"
                 }
               },
               "template": {
@@ -44,6 +47,9 @@
                 "parameters": {
                   "nsgName": {
                     "type": "string"
+                  },
+                  "priority": {
+                    "type": "Integer"
                   }
                 },
                 "resources": [
@@ -59,7 +65,7 @@
                       "sourceAddressPrefix": "*",
                       "destinationAddressPrefix": "*",
                       "access": "Deny",
-                      "priority": 100,
+                      "priority": "[parameters('priority')]",
                       "direction": "Inbound"
                     }
                   }
@@ -71,5 +77,24 @@
       } 
     },
     "parameters": {
+        "effect": {
+            "type": "String",
+            "metadata": {
+                "displayName": "Effect",
+                "description": "Enable or disable the execution of the policy"
+            },
+            "allowedValues": [
+                "DoNotEnforce",
+                "deployIfNotExists"
+            ],
+            "defaultValue": "deployIfNotExists
+       },
+       "priority": {
+           "type": "Integer",
+           "metadata": {
+              "displayName": "priority",
+              "description": "Priority for the deny RDP security rule (Example 100)."
+            }
+       }
     }
 }

--- a/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.rules.json
+++ b/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.rules.json
@@ -1,72 +1,72 @@
-{
-  "mode": "All",
-  "policyRule": {
-    "if": {
-      "field": "type",
-      "equals": "Microsoft.Network/networkSecurityGroups"  
-    },
-    "then": {
-      "effect": "deployIfNotExists",
-      "details": {
-        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
-        "roleDefinitionIds": [
-          "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
-        ],
-        "existenceCondition": {
-          "allof": [
-            {
-              "field": "Microsoft.Network/networkSecurityGroups/securityRules/access",
-              "equals": "Deny"
-            },
-            {
-              "field": "Microsoft.Network/networkSecurityGroups/securityRules/direction",
-              "equals": "Inbound"
-            },
-            {
-              "field": "Microsoft.Network/networkSecurityGroups/securityRules/destinationPortRange",
-              "equals": "3389"
-            }
-          ]
-        },
-        "deployment": {
-          "properties": {
-            "mode": "incremental",
-            "parameters": {
-              "nsgName": {
-                "value": "[field('name')]"
+  "if": {
+        "field": "type",
+        "equals": "Microsoft.Network/networkSecurityGroups"
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+          ],
+          "existenceCondition": {
+            "allof": [
+              {
+                "field": "Microsoft.Network/networkSecurityGroups/securityRules/access",
+                "equals": "Deny"
+              },
+              {
+                "field": "Microsoft.Network/networkSecurityGroups/securityRules/direction",
+                "equals": "Inbound"
+              },
+              {
+                "field": "Microsoft.Network/networkSecurityGroups/securityRules/destinationPortRange",
+                "equals": "3389"
               }
-            },
-            "template": {
-              "$schema": "http://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-              "contentVersion": "1.0.0.0",
+            ]
+          },
+          "deployment": {
+            "properties": {
+              "mode": "incremental",
               "parameters": {
                 "nsgName": {
-                  "type": "string"
+                  "value": "[field('name')]"
+                },
+                "priority": {
+                  "value": "[parameters('priority')]"
                 }
               },
-              "resources": [
-                {
-                  "name": "[concat(parameters('nsgName'),'/Port_3389_Deny')]",
-                  "type": "Microsoft.Network/networkSecurityGroups/securityRules",
-                  "apiVersion": "2019-11-01",
-                  "properties": {
-                    "description": "Deny RDP",
-                    "protocol": "*",
-                    "sourcePortRange": "*",
-                    "destinationPortRange": "3389",
-                    "sourceAddressPrefix": "*",
-                    "destinationAddressPrefix": "*",
-                    "access": "Deny",
-                    "priority": 100,
-                    "direction": "Inbound"
+              "template": {
+                "$schema": "http://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {
+                  "nsgName": {
+                    "type": "string"
+                  },
+                  "priority": {
+                    "type": "Integer"
                   }
-                }
-              ]
+                },
+                "resources": [
+                  {
+                    "name": "[concat(parameters('nsgName'),'/Port_3389_Deny')]",
+                    "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+                    "apiVersion": "2019-11-01",
+                    "properties": {
+                      "description": "Deny RDP",
+                      "protocol": "*",
+                      "sourcePortRange": "*",
+                      "destinationPortRange": "3389",
+                      "sourceAddressPrefix": "*",
+                      "destinationAddressPrefix": "*",
+                      "access": "Deny",
+                      "priority": "[parameters('priority')]",
+                      "direction": "Inbound"
+                    }
+                  }
+                ]
+              }
             }
           }
         }
       }
-    }
-  },
-  "parameters": {}
-}

--- a/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.rules.json
+++ b/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.rules.json
@@ -1,4 +1,4 @@
-  "if": {
+      "if": {
         "field": "type",
         "equals": "Microsoft.Network/networkSecurityGroups"
       },
@@ -44,7 +44,7 @@
                     "type": "string"
                   },
                   "priority": {
-                    "type": "Integer"
+                    "type": "int"
                   }
                 },
                 "resources": [

--- a/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.rules.json
+++ b/Policies/Network/deploy-security-rule-to-existing-nsg/azurepolicy.rules.json
@@ -1,0 +1,72 @@
+{
+  "mode": "All",
+  "policyRule": {
+    "if": {
+      "field": "type",
+      "equals": "Microsoft.Network/networkSecurityGroups"  
+    },
+    "then": {
+      "effect": "deployIfNotExists",
+      "details": {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "roleDefinitionIds": [
+          "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+        ],
+        "existenceCondition": {
+          "allof": [
+            {
+              "field": "Microsoft.Network/networkSecurityGroups/securityRules/access",
+              "equals": "Deny"
+            },
+            {
+              "field": "Microsoft.Network/networkSecurityGroups/securityRules/direction",
+              "equals": "Inbound"
+            },
+            {
+              "field": "Microsoft.Network/networkSecurityGroups/securityRules/destinationPortRange",
+              "equals": "3389"
+            }
+          ]
+        },
+        "deployment": {
+          "properties": {
+            "mode": "incremental",
+            "parameters": {
+              "nsgName": {
+                "value": "[field('name')]"
+              }
+            },
+            "template": {
+              "$schema": "http://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "nsgName": {
+                  "type": "string"
+                }
+              },
+              "resources": [
+                {
+                  "name": "[concat(parameters('nsgName'),'/Port_3389_Deny')]",
+                  "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+                  "apiVersion": "2019-11-01",
+                  "properties": {
+                    "description": "Deny RDP",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "3389",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "*",
+                    "access": "Deny",
+                    "priority": 100,
+                    "direction": "Inbound"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
If a platform team wishes to enforce certain security rules to every NSG that gets create they can use this "deployIfNotExists" policy to enforce some of those rules. Do note that the priority of Security rules is evaluated from lowest to highest. So ensure that certain range of priorities is reserved for the platform team so the app teams cannot add an "Allow * " which breaks the "Deny RDP".