### PR TITLE
Change Event Hub Azure Activity Policy to point to EH Rules instead of LA Workspace

### DIFF
--- a/Policies/Monitoring/deploy-diagnostic-setting-for-activity-log-event-hub/azurepolicy.json
+++ b/Policies/Monitoring/deploy-diagnostic-setting-for-activity-log-event-hub/azurepolicy.json
@@ -51,7 +51,7 @@
                 "ExistenceCondition": {
                     "allOf": [
                         {
-                            "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
+                            "field": "Microsoft.Insights/diagnosticSettings/eventHubAuthorizationRuleId",
                             "equals": "[parameters('eventHubRuleId')]"
                         },
                         {


### PR DESCRIPTION
workspaceId will be null if we are only defining event hub and this policy will never show as compliant. adjusting to eventHubAuthorizationRuleId to match the value this will create.