### PR TITLE
PostgreSQl: Added a Policy Definition on the Diagnostic Settings

### DIFF
--- a/Policies/PostgreSQL/Diagnostic Settings
+++ b/Policies/PostgreSQL/Diagnostic Settings
@@ -1,0 +1,79 @@
+{
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "name": "postgresql-diagnostic-settings-v1",
+    "properties": {
+        "displayName": "PostgreSQL - Diagnostic Settings v1",
+        "policyType": "Custom",
+        "mode": "All",
+        "description": "This Azure Policy creates an audit event when specific log (i.e. PostgreSQLLogs) and metric categories (i.e. AllMetrics) in the Diagnostic Settings are not send to a specific Log Analytics Workspace.",
+        "metadata": {
+            "version": "1.0.0",
+            "category": "PostgreSQL"
+        },
+        "parameters": {
+            "logAnalytics": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Log Analytics Workspace ID",
+                    "description": "The full resource ID for the Azure Log Analytics Workspace"
+                }
+            }
+        },
+        "policyRule": {
+            "if": {
+                "field": "type",
+                "equals": "Microsoft.DBforPostgreSQL/servers"
+            },
+            "then": {
+                "effect": "AuditIfNotExists",
+                "details": {
+                    "type": "Microsoft.Insights/diagnosticSettings",
+                    "existenceCondition": {
+                        "allOf": [
+                            {
+                                "count": {
+                                    "field": "Microsoft.Insights/diagnosticSettings/logs[*]",
+                                    "where": {
+                                        "allOf": [
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                "equals": "true"
+                                            },
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                "equals": "PostgreSQLLogs"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "equals": 1
+                            },
+                            {
+                                "count": {
+                                    "field": "Microsoft.Insights/diagnosticSettings/metrics[*]",
+                                    "where": {
+                                        "allOf": [
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/metrics[*].enabled",
+                                                "equals": "true"
+                                            },
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/metrics[*].category",
+                                                "equals": "AllMetrics"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "equals": 1
+                            },
+                            {
+                                "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
+                                "equals": "[parameters('logAnalytics')]"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I created a Policy Definition for the Azure Database for PostgreSQL service which creates an audit event when specific log (i.e. PostgreSQLLogs) and metric categories (i.e. AllMetrics) in the Diagnostic Settings are not send to a specific Log Analytics Workspace. 

You can also use this Policy Definition for other Azure Services by changing the resource type on line 25. Next to that, additional log and metric categories can be added by creating new count loops.