### PR TITLE
App Service Apps require App Gateway Front End

### DIFF
--- a/Policies/App Service/audit-appservicesbackend-appgw/README.md
+++ b/Policies/App Service/audit-appservicesbackend-appgw/README.md
@@ -1,0 +1,4 @@
+# Apps Require App Gateway Front End
+
+Custom policy to ensure that all HTTPS App Service Apps are behind an Application Gateway
+Policy checks in the backend pool of Application Gateway and ensures each App is part of the backend pool, if not the policy effect(auditIfNotExists) triggers.

--- a/Policies/App Service/audit-appservicesbackend-appgw/azurepolicy.json
+++ b/Policies/App Service/audit-appservicesbackend-appgw/azurepolicy.json
@@ -1,0 +1,45 @@
+{
+  "properties": {
+    "name": "HTTPSAppsRequireAppGWFrontEnd",
+    "displayName": "Apps Require App Gateway Front End",
+    "description": "Custom policy requires that HTTP(S) triggered apps require App GW Front-End so that inbound ports are not opened on apps",
+    "policyType": "Custom",
+    "mode": "All",
+    "metadata": {
+      "category": "App Service"
+    },
+    "parameters": {
+      "effect": {
+        "type": "string",
+        "metadata": {
+          "description": "Policy effect either disabled or auditIfNotExists"
+        },
+        "defaultValue": "auditIfNotExists",
+        "allowedValues": ["auditIfNotExists", "disabled"]
+      }
+    },
+    "policyRule": {
+      "if": {
+        "field": "type",
+        "in": ["Microsoft.Web/sites"]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.Network/applicationGateways",
+          "existenceScope": "subscription",
+          "existenceCondition": {
+            "count": {
+              "field": "Microsoft.Network/applicationGateways/backendAddressPools[*].backendAddresses[*]",
+              "where": {
+                "field": "Microsoft.Network/applicationGateways/backendAddressPools[*].backendAddresses[*].fqdn",
+                "like": "[concat(field('name'),'.','*')]"
+              }
+            },
+            "greaterOrEquals": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/audit-appservicesbackend-appgw/azurepolicy.parameters.json
+++ b/Policies/App Service/audit-appservicesbackend-appgw/azurepolicy.parameters.json
@@ -1,0 +1,10 @@
+{
+  "effect": {
+    "type": "string",
+    "metadata": {
+      "description": "Policy effect either disabled or auditIfNotExists"
+    },
+    "defaultValue": "auditIfNotExists",
+    "allowedValues": ["auditIfNotExists", "disabled"]
+  }
+}

--- a/Policies/App Service/audit-appservicesbackend-appgw/azurepolicy.rules.json
+++ b/Policies/App Service/audit-appservicesbackend-appgw/azurepolicy.rules.json
@@ -1,0 +1,23 @@
+{
+  "if": {
+    "field": "type",
+    "in": ["Microsoft.Web/sites"]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Network/applicationGateways",
+      "existenceScope": "subscription",
+      "existenceCondition": {
+        "count": {
+          "field": "Microsoft.Network/applicationGateways/backendAddressPools[*].backendAddresses[*]",
+          "where": {
+            "field": "Microsoft.Network/applicationGateways/backendAddressPools[*].backendAddresses[*].fqdn",
+            "like": "[concat(field('name'),'.','*')]"
+          }
+        },
+        "greaterOrEquals": 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Custom policy requires that HTTP(S) triggered apps require App GW Front-End so that inbound ports are not opened on apps