### PR TITLE
Network: Deny if a Private Endpoint is not deployed into a specific Subnet Prefix & Create DNS Zone vNET Integration Policy

### DIFF
--- a/Policies/Network/deny-private-endpoint-if-not-in-specific-subnet/README.md
+++ b/Policies/Network/deny-private-endpoint-if-not-in-specific-subnet/README.md
@@ -1,0 +1,61 @@
+# Only Allows Private Endpoints to Be Deployed Into A Specific Subnet
+
+This policy enforces the deployment of Azure Private Endpoints to be deployed into a VNET with a subnet that has a specific prefix in the name (i.e pls, pe). It also supports exemptions by allowing specific [Group IDs](https://docs.microsoft.com/en-us/cli/azure/network/private-endpoint?view=azure-cli-latest#az_network_private_endpoint_create-required-parameters) to be excluded from this Policy.
+
+## Try on Portal
+
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeny-private-endpoint-if-not-in-specific-subnet%2Fazurepolicy.json)
+
+[![Deploy to Azure Gov](https://docs.microsoft.com/azure/governance/policy/media/deploy/deployGovbutton.png)](https://portal.azure.us/?#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeny-private-endpoint-if-not-in-specific-subnet%2Fazurepolicy.json)
+
+Sample parameter ```subnetNamingConvention```, which can be used during policy assignment:
+```json
+{
+    "subnetName": "pe,pls",
+    "exemptedGroupIds":["table"]
+}
+```
+
+> The ```subnetName``` defines the suffix that you want to allow Private Endpoint resources to be deployed into. This is useful where you want to isolate Private Endpoints in seperate Virtual Network Spokes, using **Pattern 1** from the Azure Documentation: [Use Azure Firewall to inspect traffic destined to a private endpoint](https://docs.microsoft.com/en-us/azure/private-link/inspect-traffic-with-azure-firewall)
+
+> The ```exemptedGroupIds``` defines an array of Private Endpoint Group IDs that you want to exclude from this policy. This may be used for scenarios where certain PaaS Services deployments (i.e. AKS) automatically attempt the creation of a Private Endpoint for the API Server, and this can only live within the subnet where the AKS cluster is deployed into.
+
+
+## Try with PowerShell
+
+```powershell
+$definition = New-AzPolicyDefinition `
+    -Name "deny-pe-if-not-in-subnet" `
+    -Policy 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Network/deny-private-endpoint-if-not-in-specific-subnet/azurepolicy.rules.json' `
+    -Parameter 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Network/deny-private-endpoint-if-not-in-specific-subnet/azurepolicy.parameters.json' `
+    -Mode All
+
+$definition
+
+$policyParameterObject = @{
+    "subnetName" = "pe"
+    "exemptedGroupIds"=@("table")
+}
+
+$assignment = New-AzPolicyAssignment `
+    -Name <assignmentname> `
+    -Scope <scope> `
+    -PolicyDefinition $definition `
+    -AssignIdentity `
+    -Location <location> `
+    -PolicyParameterObject $policyParameterObject
+
+$assignment
+```
+
+## Try with CLI
+
+```sh
+az policy definition create \
+    --name 'only-allow-private-endpoints-in-subnet-with-specific-suffix' \
+    --rules 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Network/deny-private-endpoint-if-not-in-specific-subnet/azurepolicy.rules.json' \
+    --params 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Network/deny-private-endpoint-if-not-in-specific-subnet/azurepolicy.parameters.json' \
+    --mode All
+
+az policy assignment create --name <assignmentname> --scope <scope> --policy 'deny-private-endpoint-if-not-in-specific-subnet' --location <location> --params '{ "subnetName":{"value":"pls"},"exemptedGroupIds": { "value": ["table"]}}'
+```

--- a/Policies/Network/deny-private-endpoint-if-not-in-specific-subnet/azurepolicy.json
+++ b/Policies/Network/deny-private-endpoint-if-not-in-specific-subnet/azurepolicy.json
@@ -1,0 +1,55 @@
+{
+  "properties": {
+    "name": "deny-pe-if-not-in-subnet",
+    "displayName": "Deny Private Endpoints if not being deployed to a specific subnet",
+    "policyType": "Custom",
+    "mode": "All",
+    "description": "This Policy will deny the creation of Private Endpoints if not within subnets that contain a key word.",
+    "metadata": {
+      "category": "Network"
+    },
+    "parameters": {
+      "subnetName": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Allowed Subnet prefix name (i.e. pls)",
+          "description": "Name of subnet where Private Endpoints are allowed to be deployed into."
+        }
+      },
+      "exemptedGroupIds": {
+        "type": "array",
+        "metadata": {
+          "displayName": "Exempted Private Endpoint Group IDs",
+          "description": "The Group IDs that are exempted from this Policy (i.e. blob)"
+        }
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/privateEndpoints"
+          },
+          {
+            "field": "Microsoft.Network/privateEndpoints/subnet.id",
+            "notContains": "[parameters('subnetName')]"
+          },
+          {
+            "count": {
+              "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+              "where": {
+                "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+                "notIn": "[parameters('exemptedGroupIds')]"
+              }
+            },
+            "greaterOrEquals": 1
+          }
+        ]
+      },
+      "then": {
+        "effect": "deny"
+      }
+    }
+  }
+}

--- a/Policies/Network/deny-private-endpoint-if-not-in-specific-subnet/azurepolicy.parameters.json
+++ b/Policies/Network/deny-private-endpoint-if-not-in-specific-subnet/azurepolicy.parameters.json
@@ -1,0 +1,16 @@
+{
+  "subnetName": {
+    "type": "string",
+    "metadata": {
+      "displayName": "Allowed Subnet prefix name (i.e. pls)",
+      "description": "Name of subnet where Private Endpoints are allowed to be deployed into."
+    }
+  },
+  "exemptedGroupIds": {
+    "type": "array",
+    "metadata": {
+      "displayName": "Exempted Private Endpoint Group IDs",
+      "description": "The Group IDs that are exempted from this Policy (i.e. blob)"
+    }
+  }
+}

--- a/Policies/Network/deny-private-endpoint-if-not-in-specific-subnet/azurepolicy.rules.json
+++ b/Policies/Network/deny-private-endpoint-if-not-in-specific-subnet/azurepolicy.rules.json
@@ -1,0 +1,27 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Network/privateEndpoints"
+      },
+      {
+        "field": "Microsoft.Network/privateEndpoints/subnet.id",
+        "notContains": "[parameters('subnetName')]"
+      },
+      {
+        "count": {
+          "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+          "where": {
+            "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+            "notIn": "[parameters('exemptedGroupIds')]"
+          }
+        },
+        "greaterOrEquals": 1
+      }
+    ]
+  },
+  "then": {
+    "effect": "deny"
+  }
+}

--- a/Policies/Network/deploy-private-dnszone-vnet-link-to-vnets/README.md
+++ b/Policies/Network/deploy-private-dnszone-vnet-link-to-vnets/README.md
@@ -1,0 +1,63 @@
+# Create Private DNS Zone Virtual Network Link to Virtual Networks if not available
+
+This policy creates a virtual network integration for an Azure Private DNS Zone to the specified vNets Resource IDs. Can also be set to enable auto registeration for resources deployed in these vNets to the Azure Private DNS Zone.
+
+## Try on Portal
+
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeploy-private-dnszone-vnet-link-to-vnets%2Fazurepolicy.json)
+
+[![Deploy to Azure Gov](https://docs.microsoft.com/azure/governance/policy/media/deploy/deployGovbutton.png)](https://portal.azure.us/?#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeploy-private-dnszone-vnet-link-to-vnets%2Fazurepolicy.json)
+
+Sample parameter ```virtualNetworkResourceId```, which can be used during policy assignment:
+```json
+{
+    "virtualNetworkResourceId": "[
+        "/subscriptions/{subscription id}/resourceGroups/{resourceGroup name}/providers/Microsoft.Network/virtualNetworks/{virtual network 1 name}",
+        "/subscriptions/{subscription id}/resourceGroups/{resourceGroup name}/providers/Microsoft.Network/virtualNetworks/{virtual network 2 name}"
+    ]",
+    "registrationEnabled":false
+}
+```
+
+> The ```virtualNetworkResourceId``` defines Resource Ids of a vNet to link. The format must be: '/subscriptions/{subscription id}/resourceGroups/{resourceGroup name}/providers/Microsoft.Network/virtualNetworks/{virtual network name}. Can support multiple vNets
+
+> The ```registrationEnabled``` Enables automatic DNS registration in the zone for the linked vNet. Default is ```false```.
+
+
+## Try with PowerShell
+
+```powershell
+$definition = New-AzPolicyDefinition `
+    -Name "create-dnsZone-vnet-integration-to-vnets" `
+    -Policy 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Network/deploy-private-dnszone-vnet-link-to-vnets/azurepolicy.rules.json' `
+    -Parameter 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Network/deploy-private-dnszone-vnet-link-to-vnets/azurepolicy.parameters.json' `
+    -Mode All
+
+$definition
+
+$policyParameterObject = @{
+    "virtualNetworkResourceId" = @("/subscriptions/{subscription id}/resourceGroups/{resourceGroup name}/providers/Microsoft.Network/virtualNetworks/{virtual network 1 name}")
+}
+
+$assignment = New-AzPolicyAssignment `
+    -Name <assignmentname> `
+    -Scope <scope> `
+    -PolicyDefinition $definition `
+    -AssignIdentity `
+    -Location <location> `
+    -PolicyParameterObject $policyParameterObject
+
+$assignment
+```
+
+## Try with CLI
+
+```sh
+az policy definition create \
+    --name 'create-dnsZone-vnet-integration-to-vnets' \
+    --rules 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Network/deploy-private-dnszone-vnet-link-to-vnets/azurepolicy.rules.json' \
+    --params 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Network/deploy-private-dnszone-vnet-link-to-vnets/azurepolicy.parameters.json' \
+    --mode All
+
+az policy assignment create --name <assignmentname> --scope <scope> --policy 'deploy-private-dnszone-vnet-link-to-vnets' --location <location> --params '{ "virtualNetworkResourceId": { "value": ["/subscriptions/{subscription id}/resourceGroups/{resourceGroup name}/providers/Microsoft.Network/virtualNetworks/{virtual network 1 name}"]}}'
+```

--- a/Policies/Network/deploy-private-dnszone-vnet-link-to-vnets/azurepolicy.json
+++ b/Policies/Network/deploy-private-dnszone-vnet-link-to-vnets/azurepolicy.json
@@ -1,0 +1,108 @@
+{
+  "description": "Create Private DNS Zone Virtual Network Link to Virtual Networks if not available",
+  "displayName": "Create Private DNS Zone Virtual Network Link to Virtual Networks if not available",
+  "metadata": {
+    "category": "Network"
+  },
+  "mode": "All",
+  "name": "create-dnsZone-vnet-integration-to-vnets",
+  "parameters": {
+    "virtualNetworkResourceId": {
+      "defaultValue": [],
+      "metadata": {
+        "description": "Resource Ids of a vNet to link. The format must be: '/subscriptions/{subscription id}/resourceGroups/{resourceGroup name}/providers/Microsoft.Network/virtualNetworks/{virtual network name}",
+        "displayName": "Vnet Resource IDs"
+      },
+      "type": "array"
+    },
+    "registrationEnabled": {
+      "defaultValue": false,
+      "metadata": {
+        "description": "Enables automatic DNS registration in the zone for the linked vNet.",
+        "displayName": "Enable Registration"
+      },
+      "type": "Boolean"
+    }
+  },
+  "policyRule": {
+    "if": {
+      "allOf": [
+        {
+          "equals": "Microsoft.Network/privateDnsZones",
+          "field": "type"
+        }
+      ]
+    },
+    "then": {
+      "details": {
+        "existenceCondition": {
+          "allOf": [
+            {
+              "equals": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+              "field": "type"
+            },
+            {
+              "in": "[parameters('virtualNetworkResourceId')]",
+              "field": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/virtualNetwork.id"
+            }
+          ]
+        },
+        "deployment": {
+          "properties": {
+            "mode": "incremental",
+            "parameters": {
+              "privateDnsZoneName": {
+                "value": "[field('name')]"
+              },
+              "virtualNetworkResourceId": {
+                "value": "[parameters('virtualNetworkResourceId')]"
+              },
+              "registrationEnabled": {
+                "value": "[parameters('registrationEnabled')]"
+              }
+            },
+            "template": {
+              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "privateDnsZoneName": {
+                  "type": "String"
+                },
+                "virtualNetworkResourceId": {
+                  "type": "array"
+                },
+                "registrationEnabled": {
+                  "type": "bool"
+                }
+              },
+              "resources": [
+                {
+                  "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+                  "apiVersion": "2018-09-01",
+                  "name": "[concat(parameters('privateDnsZoneName'),'/',concat(parameters('privateDnsZoneName'),'-', last(split(parameters('virtualNetworkResourceId')[copyIndex()],'/'))))]",
+                  "location": "global",
+                  "copy": {
+                    "name": "vnetlink-counter",
+                    "count": "[length(parameters('virtualNetworkResourceId'))]"
+                  },
+                  "properties": {
+                    "registrationEnabled": "[parameters('registrationEnabled')]",
+                    "virtualNetwork": {
+                      "id": "[parameters('virtualNetworkResourceId')[copyIndex()]]"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "roleDefinitionIds": [
+          "/providers/microsoft.authorization/roleDefinitions/b12aa53e-6015-4669-85d0-8515ebb3ae7f"
+        ],
+        "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks"
+      },
+      "effect": "deployIfNotExists"
+    }
+  },
+  "policyType": "Custom"
+}

--- a/Policies/Network/deploy-private-dnszone-vnet-link-to-vnets/azurepolicy.parameters.json
+++ b/Policies/Network/deploy-private-dnszone-vnet-link-to-vnets/azurepolicy.parameters.json
@@ -1,0 +1,18 @@
+{
+  "virtualNetworkResourceId": {
+    "defaultValue": [],
+    "metadata": {
+      "description": "Resource Ids of a vNet to link. The format must be: '/subscriptions/{subscription id}/resourceGroups/{resourceGroup name}/providers/Microsoft.Network/virtualNetworks/{virtual network name}",
+      "displayName": "Vnet Resource IDs"
+    },
+    "type": "array"
+  },
+  "registrationEnabled": {
+    "defaultValue": false,
+    "metadata": {
+      "description": "Enables automatic DNS registration in the zone for the linked vNet.",
+      "displayName": "Enable Registration"
+    },
+    "type": "Boolean"
+  }
+}

--- a/Policies/Network/deploy-private-dnszone-vnet-link-to-vnets/azurepolicy.rules.json
+++ b/Policies/Network/deploy-private-dnszone-vnet-link-to-vnets/azurepolicy.rules.json
@@ -1,0 +1,80 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "equals": "Microsoft.Network/privateDnsZones",
+        "field": "type"
+      }
+    ]
+  },
+  "then": {
+    "details": {
+      "existenceCondition": {
+        "allOf": [
+          {
+            "equals": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+            "field": "type"
+          },
+          {
+            "in": "[parameters('virtualNetworkResourceId')]",
+            "field": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/virtualNetwork.id"
+          }
+        ]
+      },
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "parameters": {
+            "privateDnsZoneName": {
+              "value": "[field('name')]"
+            },
+            "virtualNetworkResourceId": {
+              "value": "[parameters('virtualNetworkResourceId')]"
+            },
+            "registrationEnabled": {
+              "value": "[parameters('registrationEnabled')]"
+            }
+          },
+          "template": {
+            "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "privateDnsZoneName": {
+                "type": "String"
+              },
+              "virtualNetworkResourceId": {
+                "type": "array"
+              },
+              "registrationEnabled": {
+                "type": "bool"
+              }
+            },
+            "resources": [
+              {
+                "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+                "apiVersion": "2018-09-01",
+                "name": "[concat(parameters('privateDnsZoneName'),'/',concat(parameters('privateDnsZoneName'),'-', last(split(parameters('virtualNetworkResourceId')[copyIndex()],'/'))))]",
+                "location": "global",
+                "copy": {
+                  "name": "vnetlink-counter",
+                  "count": "[length(parameters('virtualNetworkResourceId'))]"
+                },
+                "properties": {
+                  "registrationEnabled": "[parameters('registrationEnabled')]",
+                  "virtualNetwork": {
+                    "id": "[parameters('virtualNetworkResourceId')[copyIndex()]]"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "roleDefinitionIds": [
+        "/providers/microsoft.authorization/roleDefinitions/b12aa53e-6015-4669-85d0-8515ebb3ae7f"
+      ],
+      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks"
+    },
+    "effect": "deployIfNotExists"
+  }
+}


### PR DESCRIPTION
This policy enforces all private endpoints to be deployed into subnets that follow a specific prefix name. Also supports exemptions for specific Private Endpoint Group IDs if required.