### PR TITLE
DINE policy for granular AKS Diagnostic Settings to Event Hub

### DIFF
--- a/Policies/Monitoring/deploy-diagnostic-setting-for-aks-event-hub/README.md
+++ b/Policies/Monitoring/deploy-diagnostic-setting-for-aks-event-hub/README.md
@@ -1,0 +1,26 @@
+# Apply Diagnostic Settings for AKS to a Regional Event Hub
+
+This policy automatically deploys diagnostic settings for AKS supporting a regional Event Hub as a sink point. The policy parameters allow for setting specific log settings for each of the AKS sources instead of just all logs. The policy includes parameter defaults that enable all of the logs and metrics.  You can set individual log sources to false to disable them from logging to the eventhub.
+
+## Try on Portal
+
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FCommunity-Policy%2Fmaster%2FPolicies%2FMonitoring%2Fdeploy-diagnostic-setting-for-aks-event-hub%2Fazurepolicy.json)
+
+## Try with PowerShell
+
+````powershell
+$definition = New-AzPolicyDefinition -Name "deploy-diagnostic-setting-for-aks-event-hub" -DisplayName "Apply Diagnostic Settings for AKS to a Regional Event Hub" -description "This policy automatically deploys diagnostic settings for AKS to point to a regional Event Hub." -Policy 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Monitoring/deploy-diagnostic-setting-for-aks-event-hub/azurepolicy.rules.json' -Parameter 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Monitoring/deploy-diagnostic-setting-for-aks-event-hub/azurepolicy.parameters.json' -Mode All
+$definition
+$assignment = New-AzPolicyAssignment -Name <assignmentname> -Scope <scope> -eventHubRuleId <eventHubRuleId> -PolicyDefinition $definition
+$assignment 
+````
+
+## Try with CLI
+
+````cli
+
+az policy definition create --name 'deploy-diagnostic-setting-for-aks-event-hub' --display-name 'Apply Diagnostic Settings for AKS to a regional Event Hub' --description 'This policy automatically deploys diagnostic settings to AKS supporting a regional Event Hub.' --rules 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Monitoring/deploy-diagnostic-setting-for-aks-event-hub/azurepolicy.rules.json' --params 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Monitoring/deploy-diagnostic-setting-for-aks-event-hub/azurepolicy.parameters.json' --mode All
+
+az policy assignment create --name <assignmentname> --scope <scope> --params "{'eventHubRuleId': { 'value': '<eventHubRuleId>' } }" --policy "deploy-diagnostic-setting-for-aks-event-hub"
+
+````

--- a/Policies/Monitoring/deploy-diagnostic-setting-for-aks-event-hub/azurepolicy.json
+++ b/Policies/Monitoring/deploy-diagnostic-setting-for-aks-event-hub/azurepolicy.json
@@ -1,0 +1,392 @@
+{
+    "properties": {
+        "displayName": "Deploy Diagnostic Settings on Azure Kubernetes Service and send to EventHub",
+        "description": "This Policy will deploy Diagnostic Settings on Azure Kubernetes Service with parameters to individually configure the log and metrics configurations",
+        "mode": "All",
+        "policyRule": {
+            "if": {
+                "field": "type",
+                "equals": "Microsoft.ContainerService/managedClusters"
+            },
+            "then": {
+                "effect": "[parameters('effect')]",
+                "details": {
+                    "type": "Microsoft.Insights/diagnosticSettings",
+                    "roleDefinitionIds": [
+                        "/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa",
+                        "/providers/microsoft.authorization/roleDefinitions/f526a384-b230-433a-b45c-95f59c4a2dec",
+                        "/providers/microsoft.authorization/roleDefinitions/7f6c6a51-bcf8-42ba-9220-52d62157d7db"
+                    ],
+                    "existenceCondition": {
+                        "allOf": [
+                            {
+                                "field": "Microsoft.Insights/diagnosticSettings/metrics.enabled",
+                                "equals": "[parameters('AllMetrics')]"
+                            },
+                            {
+                                "field": "Microsoft.Insights/diagnosticSettings/eventHubAuthorizationRuleId",
+                                "equals": "[parameters('eventHubRuleId')]"
+                            },
+                            {
+                                "count": {
+                                    "field": "Microsoft.Insights/diagnosticSettings/logs[*]",
+                                    "where": {
+                                        "anyOf": [
+                                            {
+                                                "allOf": [
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                        "equals": "kube-audit"
+                                                    },
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                        "notEquals": "[parameters('kube-audit')]"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "allOf": [
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                        "equals": "kube-apiserver"
+                                                    },
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                        "notEquals": "[parameters('kube-apiserver')]"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "allOf": [
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                        "equals": "kube-controller-manager"
+                                                    },
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                        "notEquals": "[parameters('kube-controller-manager')]"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "allOf": [
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                        "equals": "kube-scheduler"
+                                                    },
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                        "notEquals": "[parameters('kube-scheduler')]"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "allOf": [
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                        "equals": "cluster-autoscaler"
+                                                    },
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                        "notEquals": "[parameters('cluster-autoscaler')]"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "allOf": [
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                        "equals": "kube-audit-admin"
+                                                    },
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                        "notEquals": "[parameters('kube-audit-admin')]"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "allOf": [
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                        "equals": "guard"
+                                                    },
+                                                    {
+                                                        "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                        "notEquals": "[parameters('guard')]"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "equals": 0
+                            }
+                        ]
+                    },
+                    "deployment": {
+                        "properties": {
+                            "mode": "incremental",
+                            "template": {
+                                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                                "contentVersion": "1.0.0.0",
+                                "parameters": {
+                                    "diagnosticsSettingNameToUse": {
+                                        "type": "string"
+                                    },
+                                    "resourceName": {
+                                        "type": "string"
+                                    },
+                                    "eventHubRuleId": {
+                                        "type": "string"
+                                    },
+                                    "location": {
+                                        "type": "string"
+                                    },
+                                    "AllMetrics": {
+                                        "type": "string"
+                                    },
+                                    "kube-apiserver": {
+                                        "type": "string"
+                                    },
+                                    "kube-audit": {
+                                        "type": "string"
+                                    },
+                                    "kube-controller-manager": {
+                                        "type": "string"
+                                    },
+                                    "kube-scheduler": {
+                                        "type": "string"
+                                    },
+                                    "cluster-autoscaler": {
+                                        "type": "string"
+                                    },
+                                    "kube-audit-admin": {
+                                        "type": "string"
+                                    },
+                                    "guard": {
+                                        "type": "string"
+                                    }
+                                },
+                                "variables": {},
+                                "resources": [
+                                    {
+                                        "type": "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings",
+                                        "apiVersion": "2017-05-01-preview",
+                                        "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('diagnosticsSettingNameToUse'))]",
+                                        "location": "[parameters('location')]",
+                                        "dependsOn": [],
+                                        "properties": {
+                                            "eventHubAuthorizationRuleId": "[parameters('eventHubRuleId')]",
+                                            "metrics": [
+                                                {
+                                                    "category": "AllMetrics",
+                                                    "enabled": "[parameters('AllMetrics')]"
+                                                }
+                                            ],
+                                            "logs": [
+                                                {
+                                                    "category": "kube-apiserver",
+                                                    "enabled": "[parameters('kube-apiserver')]"
+                                                },
+                                                {
+                                                    "category": "kube-audit",
+                                                    "enabled": "[parameters('kube-audit')]"
+                                                },
+                                                {
+                                                    "category": "kube-controller-manager",
+                                                    "enabled": "[parameters('kube-controller-manager')]"
+                                                },
+                                                {
+                                                    "category": "kube-scheduler",
+                                                    "enabled": "[parameters('kube-scheduler')]"
+                                                },
+                                                {
+                                                    "category": "cluster-autoscaler",
+                                                    "enabled": "[parameters('cluster-autoscaler')]"
+                                                },
+                                                {
+                                                    "category": "kube-audit-admin",
+                                                    "enabled": "[parameters('kube-audit-admin')]"
+                                                },
+                                                {
+                                                    "category": "guard",
+                                                    "enabled": "[parameters('guard')]"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "outputs": {}
+                            },
+                            "parameters": {
+                                "diagnosticsSettingNameToUse": {
+                                    "value": "[parameters('diagnosticsSettingNameToUse')]"
+                                },
+                                "eventHubRuleId": {
+                                    "value": "[parameters('eventHubRuleId')]"
+                                },
+                                "location": {
+                                    "value": "[field('location')]"
+                                },
+                                "resourceName": {
+                                    "value": "[field('name')]"
+                                },
+                                "guard": {
+                                    "value": "[parameters('guard')]"
+                                },
+                                "AllMetrics": {
+                                    "value": "[parameters('AllMetrics')]"
+                                },
+                                "kube-apiserver": {
+                                    "value": "[parameters('kube-apiserver')]"
+                                },
+                                "kube-audit": {
+                                    "value": "[parameters('kube-audit')]"
+                                },
+                                "kube-scheduler": {
+                                    "value": "[parameters('kube-scheduler')]"
+                                },
+                                "kube-controller-manager": {
+                                    "value": "[parameters('kube-controller-manager')]"
+                                },
+                                "cluster-autoscaler": {
+                                    "value": "[parameters('cluster-autoscaler')]"
+                                },
+                                "kube-audit-admin": {
+                                    "value": "[parameters('kube-audit-admin')]"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "parameters": {
+            "effect": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "Enable or disable the execution of the policy"
+                },
+                "allowedValues": [
+                    "DeployIfNotExists",
+                    "Disabled"
+                ],
+                "defaultValue": "DeployIfNotExists"
+            },
+            "diagnosticsSettingNameToUse": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Setting name",
+                    "description": "Name of the diagnostic settings."
+                },
+                "defaultValue": "AzureKubernetesDiagnosticsLogsToEventHub"
+            },
+            "eventHubRuleId": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Event Hub Authorization Rule Id",
+                    "description": "The Event Hub authorization rule Id for Azure Diagnostics. The authorization rule needs to be at Event Hub namespace level. e.g. /subscriptions/{subscription Id}/resourceGroups/{resource group}/providers/Microsoft.EventHub/namespaces/{Event Hub namespace}/authorizationrules/{authorization rule}",
+                    "strongType": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+                    "assignPermissions": true
+                }
+            },
+            "AllMetrics": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "AllMetrics - Enabled",
+                    "description": "Whether to stream AllMetrics logs to the Event Hub - True or False"
+                },
+                "allowedValues": [
+                    "True",
+                    "False"
+                ],
+                "defaultValue": "True"
+            },
+            "kube-apiserver": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "kube-apiserver - Enabled",
+                    "description": "Whether to stream kube-apiserver logs to the Event Hub - True or False"
+                },
+                "allowedValues": [
+                    "True",
+                    "False"
+                ],
+                "defaultValue": "True"
+            },
+            "kube-audit": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "kube-audit - Enabled",
+                    "description": "Whether to stream kube-audit logs to the Event Hub - True or False"
+                },
+                "allowedValues": [
+                    "True",
+                    "False"
+                ],
+                "defaultValue": "True"
+            },
+            "kube-controller-manager": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "kube-controller-manager - Enabled",
+                    "description": "Whether to stream kube-controller-manager logs to the Event Hub - True or False"
+                },
+                "allowedValues": [
+                    "True",
+                    "False"
+                ],
+                "defaultValue": "True"
+            },
+            "kube-scheduler": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "kube-scheduler - Enabled",
+                    "description": "Whether to stream kube-scheduler logs to the Event Hub - True or False"
+                },
+                "allowedValues": [
+                    "True",
+                    "False"
+                ],
+                "defaultValue": "True"
+            },
+            "cluster-autoscaler": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "cluster-autoscaler - Enabled",
+                    "description": "Whether to stream cluster-autoscaler logs to the Event Hub - True or False"
+                },
+                "allowedValues": [
+                    "True",
+                    "False"
+                ],
+                "defaultValue": "True"
+            },
+            "kube-audit-admin": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "kube-audit-admin - Enabled",
+                    "description": "Whether to stream kube-audit-admin logs to the Event Hub - True or False"
+                },
+                "allowedValues": [
+                    "True",
+                    "False"
+                ],
+                "defaultValue": "True"
+            },
+            "guard": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "guard - Enabled",
+                    "description": "Whether to stream guard logs to the Event Hub - True or False"
+                },
+                "allowedValues": [
+                    "True",
+                    "False"
+                ],
+                "defaultValue": "True"
+            }
+        }
+    }
+}

--- a/Policies/Monitoring/deploy-diagnostic-setting-for-aks-event-hub/azurepolicy.parameters.json
+++ b/Policies/Monitoring/deploy-diagnostic-setting-for-aks-event-hub/azurepolicy.parameters.json
@@ -1,0 +1,127 @@
+{
+    "effect": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+            "DeployIfNotExists",
+            "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists"
+    },
+    "diagnosticsSettingNameToUse": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Setting name",
+            "description": "Name of the diagnostic settings."
+        },
+        "defaultValue": "AzureKubernetesDiagnosticsLogsToEventHub"
+    },
+    "eventHubRuleId": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Event Hub Authorization Rule Id",
+            "description": "The Event Hub authorization rule Id for Azure Diagnostics. The authorization rule needs to be at Event Hub namespace level. e.g. /subscriptions/{subscription Id}/resourceGroups/{resource group}/providers/Microsoft.EventHub/namespaces/{Event Hub namespace}/authorizationrules/{authorization rule}",
+            "strongType": "Microsoft.EventHub/Namespaces/AuthorizationRules",
+            "assignPermissions": true
+        }
+    },
+    "AllMetrics": {
+        "type": "String",
+        "metadata": {
+            "displayName": "AllMetrics - Enabled",
+            "description": "Whether to stream AllMetrics logs to the Event Hub - True or False"
+        },
+        "allowedValues": [
+            "True",
+            "False"
+        ],
+        "defaultValue": "True"
+    },
+    "kube-apiserver": {
+        "type": "String",
+        "metadata": {
+            "displayName": "kube-apiserver - Enabled",
+            "description": "Whether to stream kube-apiserver logs to the Event Hub - True or False"
+        },
+        "allowedValues": [
+            "True",
+            "False"
+        ],
+        "defaultValue": "True"
+    },
+    "kube-audit": {
+        "type": "String",
+        "metadata": {
+            "displayName": "kube-audit - Enabled",
+            "description": "Whether to stream kube-audit logs to the Event Hub - True or False"
+        },
+        "allowedValues": [
+            "True",
+            "False"
+        ],
+        "defaultValue": "True"
+    },
+    "kube-controller-manager": {
+        "type": "String",
+        "metadata": {
+            "displayName": "kube-controller-manager - Enabled",
+            "description": "Whether to stream kube-controller-manager logs to the Event Hub - True or False"
+        },
+        "allowedValues": [
+            "True",
+            "False"
+        ],
+        "defaultValue": "True"
+    },
+    "kube-scheduler": {
+        "type": "String",
+        "metadata": {
+            "displayName": "kube-scheduler - Enabled",
+            "description": "Whether to stream kube-scheduler logs to the Event Hub - True or False"
+        },
+        "allowedValues": [
+            "True",
+            "False"
+        ],
+        "defaultValue": "True"
+    },
+    "cluster-autoscaler": {
+        "type": "String",
+        "metadata": {
+            "displayName": "cluster-autoscaler - Enabled",
+            "description": "Whether to stream cluster-autoscaler logs to the Event Hub - True or False"
+        },
+        "allowedValues": [
+            "True",
+            "False"
+        ],
+        "defaultValue": "True"
+    },
+    "kube-audit-admin": {
+        "type": "String",
+        "metadata": {
+            "displayName": "kube-audit-admin - Enabled",
+            "description": "Whether to stream kube-audit-admin logs to the Event Hub - True or False"
+        },
+        "allowedValues": [
+            "True",
+            "False"
+        ],
+        "defaultValue": "True"
+    },
+    "guard": {
+        "type": "String",
+        "metadata": {
+            "displayName": "guard - Enabled",
+            "description": "Whether to stream guard logs to the Event Hub - True or False"
+        },
+        "allowedValues": [
+            "True",
+            "False"
+        ],
+        "defaultValue": "True"
+    }
+}

--- a/Policies/Monitoring/deploy-diagnostic-setting-for-aks-event-hub/azurepolicy.rules.json
+++ b/Policies/Monitoring/deploy-diagnostic-setting-for-aks-event-hub/azurepolicy.rules.json
@@ -1,0 +1,258 @@
+{
+    "if": {
+        "field": "type",
+        "equals": "Microsoft.ContainerService/managedClusters"
+    },
+    "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+            "type": "Microsoft.Insights/diagnosticSettings",
+            "roleDefinitionIds": [
+                "/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa",
+                "/providers/microsoft.authorization/roleDefinitions/f526a384-b230-433a-b45c-95f59c4a2dec",
+                "/providers/microsoft.authorization/roleDefinitions/7f6c6a51-bcf8-42ba-9220-52d62157d7db"
+            ],
+            "existenceCondition": {
+                "allOf": [
+                    {
+                        "field": "Microsoft.Insights/diagnosticSettings/metrics.enabled",
+                        "equals": "[parameters('AllMetrics')]"
+                    },
+                    {
+                        "field": "Microsoft.Insights/diagnosticSettings/eventHubAuthorizationRuleId",
+                        "equals": "[parameters('eventHubRuleId')]"
+                    },
+                    {
+                        "count": {
+                            "field": "Microsoft.Insights/diagnosticSettings/logs[*]",
+                            "where": {
+                                "anyOf": [
+                                    {
+                                        "allOf": [
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                "equals": "kube-audit"
+                                            },
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                "notEquals": "[parameters('kube-audit')]"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "allOf": [
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                "equals": "kube-apiserver"
+                                            },
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                "notEquals": "[parameters('kube-apiserver')]"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "allOf": [
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                "equals": "kube-controller-manager"
+                                            },
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                "notEquals": "[parameters('kube-controller-manager')]"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "allOf": [
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                "equals": "kube-scheduler"
+                                            },
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                "notEquals": "[parameters('kube-scheduler')]"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "allOf": [
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                "equals": "cluster-autoscaler"
+                                            },
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                "notEquals": "[parameters('cluster-autoscaler')]"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "allOf": [
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                "equals": "kube-audit-admin"
+                                            },
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                "notEquals": "[parameters('kube-audit-admin')]"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "allOf": [
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].category",
+                                                "equals": "guard"
+                                            },
+                                            {
+                                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                                "notEquals": "[parameters('guard')]"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "equals": 0
+                    }
+                ]
+            },
+            "deployment": {
+                "properties": {
+                    "mode": "incremental",
+                    "template": {
+                        "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                        "contentVersion": "1.0.0.0",
+                        "parameters": {
+                            "diagnosticsSettingNameToUse": {
+                                "type": "string"
+                            },
+                            "resourceName": {
+                                "type": "string"
+                            },
+                            "eventHubRuleId": {
+                                "type": "string"
+                            },
+                            "location": {
+                                "type": "string"
+                            },
+                            "AllMetrics": {
+                                "type": "string"
+                            },
+                            "kube-apiserver": {
+                                "type": "string"
+                            },
+                            "kube-audit": {
+                                "type": "string"
+                            },
+                            "kube-controller-manager": {
+                                "type": "string"
+                            },
+                            "kube-scheduler": {
+                                "type": "string"
+                            },
+                            "cluster-autoscaler": {
+                                "type": "string"
+                            },
+                            "kube-audit-admin": {
+                                "type": "string"
+                            },
+                            "guard": {
+                                "type": "string"
+                            }
+                        },
+                        "variables": {},
+                        "resources": [
+                            {
+                                "type": "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings",
+                                "apiVersion": "2017-05-01-preview",
+                                "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('diagnosticsSettingNameToUse'))]",
+                                "location": "[parameters('location')]",
+                                "dependsOn": [],
+                                "properties": {
+                                    "eventHubAuthorizationRuleId": "[parameters('eventHubRuleId')]",
+                                    "metrics": [
+                                        {
+                                            "category": "AllMetrics",
+                                            "enabled": "[parameters('AllMetrics')]"
+                                        }
+                                    ],
+                                    "logs": [
+                                        {
+                                            "category": "kube-apiserver",
+                                            "enabled": "[parameters('kube-apiserver')]"
+                                        },
+                                        {
+                                            "category": "kube-audit",
+                                            "enabled": "[parameters('kube-audit')]"
+                                        },
+                                        {
+                                            "category": "kube-controller-manager",
+                                            "enabled": "[parameters('kube-controller-manager')]"
+                                        },
+                                        {
+                                            "category": "kube-scheduler",
+                                            "enabled": "[parameters('kube-scheduler')]"
+                                        },
+                                        {
+                                            "category": "cluster-autoscaler",
+                                            "enabled": "[parameters('cluster-autoscaler')]"
+                                        },
+                                        {
+                                            "category": "kube-audit-admin",
+                                            "enabled": "[parameters('kube-audit-admin')]"
+                                        },
+                                        {
+                                            "category": "guard",
+                                            "enabled": "[parameters('guard')]"
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        "outputs": {}
+                    },
+                    "parameters": {
+                        "diagnosticsSettingNameToUse": {
+                            "value": "[parameters('diagnosticsSettingNameToUse')]"
+                        },
+                        "eventHubRuleId": {
+                            "value": "[parameters('eventHubRuleId')]"
+                        },
+                        "location": {
+                            "value": "[field('location')]"
+                        },
+                        "resourceName": {
+                            "value": "[field('name')]"
+                        },
+                        "guard": {
+                            "value": "[parameters('guard')]"
+                        },
+                        "AllMetrics": {
+                            "value": "[parameters('AllMetrics')]"
+                        },
+                        "kube-apiserver": {
+                            "value": "[parameters('kube-apiserver')]"
+                        },
+                        "kube-audit": {
+                            "value": "[parameters('kube-audit')]"
+                        },
+                        "kube-scheduler": {
+                            "value": "[parameters('kube-scheduler')]"
+                        },
+                        "kube-controller-manager": {
+                            "value": "[parameters('kube-controller-manager')]"
+                        },
+                        "cluster-autoscaler": {
+                            "value": "[parameters('cluster-autoscaler')]"
+                        },
+                        "kube-audit-admin": {
+                            "value": "[parameters('kube-audit-admin')]"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This request allows configuring Diagnostic settings to event hub for each individual log value instead of just all logs and all metrics.  This ensure that the policy compliance matches the configuration.