### PR TITLE
fix broken 'disallowed role definition' policy

### DIFF
--- a/Policies/Authorization/disallowed-role-definitions/azurepolicy.json
+++ b/Policies/Authorization/disallowed-role-definitions/azurepolicy.json
@@ -8,7 +8,7 @@
             "roleDefinitionIds": {
                 "type": "array",
                 "metadata": {
-                    "description": "The list of disallowed role definition IDs. Example: If you were to put in 8e3af657-a8ff-443c-a75c-2fe8c4bcb635 as a value then only the Owner role definition could be assigned.",
+                    "description": "The list of disallowed role definition IDs. Example: If you were to put in 8e3af657-a8ff-443c-a75c-2fe8c4bcb635 as a value then the Owner role could not be assigned.",
                     "displayName": "Not Approved Role Definitions"
                 }
             },
@@ -18,7 +18,7 @@
                     "displayName": "Exempt Principal IDs",
                     "description": "Any Principal IDs included in this list will not have this Policy applied to them."
                 },
-                "defaultvalue": "None"
+                "defaultvalue": []
             },
             "effect": {
                 "type": "String",
@@ -41,7 +41,7 @@
                         "equals": "Microsoft.Authorization/roleAssignments"
                     },
                     {
-                        "value": "[split(field('Microsoft.Authorization/roleAssignments/roleDefinitionId'),'/')[6]]",
+                        "value": "[last(split(field('Microsoft.Authorization/roleAssignments/roleDefinitionId'),'/'))]",
                         "in": "[parameters('roleDefinitionIds')]"
                     },
                     {

--- a/Policies/Authorization/disallowed-role-definitions/azurepolicy.parameters.json
+++ b/Policies/Authorization/disallowed-role-definitions/azurepolicy.parameters.json
@@ -2,7 +2,7 @@
 	"roleDefinitionIds": {
 		"type": "array",
 		"metadata": {
-			"description": "The list of disallowed role definition IDs. Example: If you were to put in 8e3af657-a8ff-443c-a75c-2fe8c4bcb635 as a value then only the Owner role definition could be assigned.",
+			"description": "The list of disallowed role definition IDs. Example: If you were to put in 8e3af657-a8ff-443c-a75c-2fe8c4bcb635 as a value then the Owner role could not be assigned.",
 			"displayName": "Not Approved Role Definitions"
 		}
 	},
@@ -12,7 +12,7 @@
 			"displayName": "Exempt Principal IDs",
 			"description": "Any Principal IDs included in this list will not have this Policy applied to them."
 		},
-		"defaultvalue": "None"
+		"defaultvalue": []
 	},
 	"effect": {
 		"type": "String",

--- a/Policies/Authorization/disallowed-role-definitions/azurepolicy.rules.json
+++ b/Policies/Authorization/disallowed-role-definitions/azurepolicy.rules.json
@@ -6,7 +6,7 @@
 				"equals": "Microsoft.Authorization/roleAssignments"
 			},
 			{
-				"value": "[split(field('Microsoft.Authorization/roleAssignments/roleDefinitionId'),'/')[6]]",
+				"value": "[last(split(field('Microsoft.Authorization/roleAssignments/roleDefinitionId'),'/'))]",
 				"in": "[parameters('roleDefinitionIds')]"
 			},
 			{


### PR DESCRIPTION
Fixes 3 issues with the current policy:

- The function which splits the role definition doesn't work - it triggers an error during policy evaluation
- the default value for the 'exemptPrincipalIDs' parameter is a string, but the parameter type is array, causing an error during definition creation
- The parameter description for 'roleDefinitionIds' is wrong - it said the opposite of what it should say