### PR TITLE
Creation of Address Limitation Policy to Support Hub/Spoke

### DIFF
--- a/Policies/Network/address-space-should-be-pre-allocated-for-region/README.md
+++ b/Policies/Network/address-space-should-be-pre-allocated-for-region/README.md
@@ -1,0 +1,32 @@
+# Address space must be pre-allocated to region
+Following the release of the ability to update the address space of a peered VNET (and resync), it becomes prudent when at "enterprise scale" (and utilising a hub-spoke topology) to restrict the ranges which spokes may utilise. Failing to do so has the potential for this to be used as an attack vector (both intentionally and unintentionally) to null-route traffic intended for on-premise (i.e. over ExpressRoute).
+
+This policy provides a mechanism for preventing a VNET's address space from existing outside of ranges configured for a region, leveraging the name of the subscription to define the environment (e.g. PROD, DEV). This is ideal in situations where an enterprise has implemented sane IPAM, and in instances where the contents of a subscription is entirely under the control of the development team.
+
+## Potential Alternative Scenarios
+- We as an organisation don't utilise the subscription name to identify the environment
+    - This policy could be edited on line 68 of `azurepolicy.json` to make use of tagging on the resource group, subscription or resource. **However**, this is more likely to be worked around dependent on your RBAC implementation.
+- We only want this to apply to VNETs directly peered with our hubs
+    - Pass in an array of subscriptionIds of where hub VNETs exist as part of the "hubSubscriptions" parameter.
+- We're utilising vWAN... What are our 'hubSubscriptions'?
+    - Review any audit trails, or a configuration of one of your spokes; each hub should/may be in its own subscription, which will be shown in the peering configuration/audit logs.
+
+# Deployment Options
+The below sectionals provide examples of how this can be deployed - please note, when utilising the "Deploy to Azure" button, some properties are ignored by the portal (e.g. non-compliance message). This will need to be manually filled. 
+
+## Deploy via Portal
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-policy%2Fmaster%2Fsamples%2FNetwork%2Faddress-space-must-be-pre-allocated-for-region%2Fazurepolicy.json)
+
+## Deploy via PowerShell
+```PowerShell
+$definition = New-AzPolicyDefinition -Name "Address space must be pre-allocated for region" -DisplayName "VNETs should abide by regional IPAM allocations" -description "This policy ensures that the address space allocated to a VNET has been pre-allocated for use within Azure, preventing peerings being utilised as an attack vector for null-routing traffic on the platform." -Policy 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.rules.json' -Parameter 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.parameters.json' -Mode Indexed
+$assignment = New-AzPolicyAssignment -Name <assignmentname> -Scope <scope> -PolicyDefinition $definition
+```
+## Deploy via Az CLI
+````cli
+
+az policy definition create --name 'Address space must be pre-allocated for region' --display-name 'VNETs should abide by regional IPAM allocations' --description 'This policy ensures that the address space allocated to a VNET has been pre-allocated for use within Azure, preventing peerings being utilised as an attack vector for null-routing traffic on the platform.' --rules 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.parameters.json' --params 'https://raw.githubusercontent.com/Azure/azure-policy/master/samples/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.parameters.json' --mode Indexed
+
+az policy assignment create --name <assignmentname> --scope <scope> --policy "Address space must be pre-allocated for region" 
+
+````

--- a/Policies/Network/address-space-should-be-pre-allocated-for-region/azurepolicy.json
+++ b/Policies/Network/address-space-should-be-pre-allocated-for-region/azurepolicy.json
@@ -1,0 +1,128 @@
+{
+    "properties": {
+      "displayName": "Address space must be pre-allocated for region",
+      "description": "This policy ensures that the address space allocated to a VNET has been pre-allocated for use within Azure, preventing peerings being utilised as an attack vector for null-routing traffic on the platform.",
+      "mode": "Indexed",
+      "nonComplianceMessages": [
+        {
+          "message": "Azure has a pre-allocation of unique ranges, with ranges allocated at subscription creation. Remove the unauthorised address space to return functionality."
+        }
+      ],
+      "metadata": {
+        "version": "0.0.1-preview",
+        "category": "Network (Custom)",
+        "portalReview": "true"
+      },
+      "parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Set whether the policy should be enforced, or an audit trail should be established."
+          },
+          "allowedValues": [
+            "Deny",
+            "Audit",
+            "Disabled"
+          ],
+          "defaultValue": "Deny"
+        },
+        "spokeAllocations": {
+          "type": "Array",
+          "metadata": {
+            "displayName": "Regional CIDR Allocations",
+            "description": "An array of CIDR objects (environment, location and CIDR), to be compared against CIDRs allocated to VNET resources."
+          },
+          "defaultValue": [
+            {
+              "environment": "DEV",
+              "location": "westeurope",
+              "CIDR": "10.2.0.0/16"
+            },
+            {
+              "environment": "PROD",
+              "location": "northeurope",
+              "CIDR": "10.1.0.0/16"
+            }
+          ]
+        },
+        "hubSubscriptions": {
+          "type": "Array",
+          "metadata": {
+            "displayName": "(Optional) Hub Subscription IDs",
+            "description": "An array of subscriptionIDs to which VNETs are peered; will cause the policy to only evaluate VNETs associated directly with your hubs."
+          }
+        }
+      },
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "allOf": [
+                {
+                  "field": "type",
+                  "equals": "Microsoft.Network/virtualNetworks"
+                },
+                {
+                  "field": "Microsoft.Network/virtualNetworks/addressSpace",
+                  "exists": true
+                },
+                {
+                  "value": "[length(field('Microsoft.Network/virtualNetworks/addressSpace'))]",
+                  "greater": 0
+                }
+              ]
+            },
+            {
+              "allOf": [
+                {
+                  "value": "[length(parameters('hubSubscriptions'))]",
+                  "greater": 0
+                },
+                {
+                  "count": {
+                    "field": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*]",
+                    "where": {
+                      "allOf": [
+                        {
+                            "value": "[split(field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*].remoteVirtualNetwork.id'), '/')[2]]",
+                            "in": "[parameters('hubSubscriptions')]"
+                        }
+                      ]
+                    }
+                  },
+                  "greater": 0
+                }
+              ]
+            },
+            {
+              "count": {
+                "value": "[parameters('spokeAllocations')]",
+                "name": "spokeAllocation",
+                "where": {
+                  "allOf": [
+                    {
+                      "value": "[subscription().displayName]",
+                      "contains": "[current('spokeAllocation').environment]"
+                    },
+                    {
+                      "field": "location",
+                      "equals": "[current('spokeAllocation').location]"
+                    },
+                    {
+                      "value": "[ipRangeContains(current('spokeAllocation').CIDR, first(field('Microsoft.Network/virtualNetworks/addressSpace.addressPrefixes[*]')))]",
+                      "equals": true
+                    }
+                  ]
+                }
+              },
+              "notequals": "[length(field('Microsoft.Network/virtualNetworks/addressSpace.addressPrefixes'))]"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]"
+        }
+      }
+    }
+  }

--- a/Policies/Network/address-space-should-be-pre-allocated-for-region/azurepolicy.parameters.json
+++ b/Policies/Network/address-space-should-be-pre-allocated-for-region/azurepolicy.parameters.json
@@ -1,0 +1,41 @@
+{
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Set whether the policy should be enforced, or an audit trail should be established."
+      },
+      "allowedValues": [
+        "Deny",
+        "Audit",
+        "Disabled"
+      ],
+      "defaultValue": "Deny"
+    },
+    "spokeAllocations": {
+      "type": "Array",
+      "metadata": {
+        "displayName": "Regional CIDR Allocations",
+        "description": "An array of CIDR objects (environment, location and CIDR), to be compared against CIDRs allocated to VNET resources."
+      },
+      "defaultValue": [
+        {
+          "environment": "DEV",
+          "location": "westeurope",
+          "CIDR": "10.2.0.0/16"
+        },
+        {
+          "environment": "PROD",
+          "location": "northeurope",
+          "CIDR": "10.1.0.0/16"
+        }
+      ]
+    },
+    "hubSubscriptions": {
+      "type": "Array",
+      "metadata": {
+        "displayName": "(Optional) Hub Subscription IDs",
+        "description": "An array of subscriptionIDs to which VNETs are peered; will cause the policy to only evaluate VNETs associated directly with your hubs."
+      }
+    }
+  }

--- a/Policies/Network/address-space-should-be-pre-allocated-for-region/azurepolicy.rules.json
+++ b/Policies/Network/address-space-should-be-pre-allocated-for-region/azurepolicy.rules.json
@@ -1,0 +1,70 @@
+{
+    "if": {
+      "allOf": [
+        {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Network/virtualNetworks"
+            },
+            {
+              "field": "Microsoft.Network/virtualNetworks/addressSpace",
+              "exists": true
+            },
+            {
+              "value": "[length(field('Microsoft.Network/virtualNetworks/addressSpace'))]",
+              "greater": 0
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "value": "[length(parameters('hubSubscriptions'))]",
+              "greater": 0
+            },
+            {
+              "count": {
+                "field": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*]",
+                "where": {
+                  "allOf": [
+                    {
+                        "value": "[split(field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*].remoteVirtualNetwork.id'), '/')[2]]",
+                        "in": "[parameters('hubSubscriptions')]"
+                    }
+                  ]
+                }
+              },
+              "greater": 0
+            }
+          ]
+        },
+        {
+          "count": {
+            "value": "[parameters('spokeAllocations')]",
+            "name": "spokeAllocation",
+            "where": {
+              "allOf": [
+                {
+                  "value": "[subscription().displayName]",
+                  "contains": "[current('spokeAllocation').environment]"
+                },
+                {
+                  "field": "location",
+                  "equals": "[current('spokeAllocation').location]"
+                },
+                {
+                  "value": "[ipRangeContains(current('spokeAllocation').CIDR, first(field('Microsoft.Network/virtualNetworks/addressSpace.addressPrefixes[*]')))]",
+                  "equals": true
+                }
+              ]
+            }
+          },
+          "notequals": "[length(field('Microsoft.Network/virtualNetworks/addressSpace.addressPrefixes'))]"
+        }
+      ]
+    },
+    "then": {
+      "effect": "[parameters('effect')]"
+    }
+  }


### PR DESCRIPTION
# Overview
Following the release of the ability to update the address space of a peered VNET (and resync), it becomes prudent when at "enterprise scale" (and utilising a hub-spoke topology) to restrict the ranges which spokes may utilise. Failing to do so has the potential for this to be used as an attack vector (both intentionally and unintentionally) to null-route traffic intended for on-premise (i.e. over ExpressRoute).

This policy provides a mechanism for preventing a VNET's address space from existing outside of ranges configured for a region, leveraging the name of the subscription to define the environment (e.g. PROD, DEV). This is ideal in situations where an enterprise has implemented sane IPAM, and in instances where the contents of a subscription is entirely under the control of the development team.

Predominately works to remove cognitive load (i.e. someone developing themselves into a poor addressing situation), and to ensure strong alignment with a company's IPAM requirements. 

# Notes
- For vWAN backed hub-spoke topologies, the subscriptionId (to utilise "hubSubscriptions") can be gained from the peering's settings - or as part of an audit log for this policy
- Not supplying a list of "hubSubscriptions" will cause all VNETs to be evaluated by the policy; supplying at least one hubSubscription will cause only VNETs peered directly to the given ID to be evaluated.
- This policy utilises the name of the subscription (e.g. MyCool-PROD-Subscription) to provide a distinction around what environment; it could be modified to utilise tags, but permissions to influence these is a lot easier found (than that to rename a subscription). 

This fulfils a specific use-case (and objectives) that I had, so open to any commentary or suggestions here :)

#1P2RTA
