### PR TITLE
Enable backup of VMs to existing RSV in the same subscription

### DIFF
--- a/Policies/Backup/vm-backup-without-tag/README.md
+++ b/Policies/Backup/vm-backup-without-tag/README.md
@@ -1,0 +1,50 @@
+# Azure VM Backup - Without Tag
+
+This custom Azure Policy will enroll all VMs WITHOUT the specified "tagName : [tagValue]" into a specified backupPolicy.  
+Additional parameters that are required for this policy include:
+* the name of the backupVaultResourceGroup
+* the name of the backupVault (Recovery Services Vault)
+* the name of the backupVaultPolicy
+
+This policy will enroll any existing VMs into the backup policy (through a remediation task) as well as any newly created VMs.
+
+## Try on Portal
+
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fcommunity-policy%2Fmaster%2Fpolicies%2FBackup%2vm-backup-without-tag%2Fazurepolicy.json)
+
+## Try with PowerShell
+
+```powershell
+
+$Scope = (Get-AzContext).Subscription.Id
+$Properties = @{
+    Name = 'backup-vm-without-given-tag-to-existing-recovery-services-vault'
+    DisplayName = 'Enable Backup on VMs without a given tag to an existing recovery services vault'
+    Description = 'Enable backup on VMs by backing them up to an existing central recovery services vault. You can optionally exclude virtual machines containing a specified tag to control the scope of assignment.'
+    Policy = 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Backup/vm-backup-without-tag/azurepolicy.rules.json'
+    Parameter = 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Backup/vm-backup-without-tag/azurepolicy.parameters.json'
+    Mode = 'All'
+}
+
+$PolicyDefinition = New-AzPolicyDefinition @Properties
+
+New-AzPolicyAssignment -Name $Properties.Name ` 
+    -DisplayName $Properties.DisplayName ` 
+    -Scope <scope> `
+    -PolicyDefinition $PolicyDefinition ` 
+    -effect <deployIfNotExists|Disabled> `
+    -backupVaultResourceGroup <resourceGroupName> `
+    -backupVault <rsvName> `
+    -backupPolicy <rsvPolicyName>
+
+```
+
+## Try with CLI
+
+```cli
+
+az policy definition create --name 'backup-vm-without-given-tag-to-existing-recovery-services-vault' --display-name 'Enable Backup on virtual machines without a given tag to an existing recovery services vault' --description 'Enable backup for virtual machines by backing them up to an existing central recovery services vault. You can optionally exclude virtual machines containing a specified tag to control the scope of assignment.' --rules 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Backup/vm-backup-without-tag/azurepolicy.rules.json' --params 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Backup/vm-backup-without-tag/azurepolicy.parameters.json' --mode All
+
+az policy assignment create --name 'backup-vm-without-given-tag-to-existing-recovery-services-vault' --display-name 'Enable Backup on virtual machines without a given tag to an existing recovery services vault' --scope <scope> --params "{ 'effect': { 'value': '<deployIfNotExists|Disabled>' }, 'backupVaultResourceGroup': { 'value': '<resourceGroupName>' },'backupVault': { 'value': '<rsvName>' },'backupPolicy': { 'value': '<rsvPolicyName>' } }" --policy "backup-vm-without-given-tag-to-existing-recovery-services-vault"
+
+```

--- a/Policies/Backup/vm-backup-without-tag/azurepolicy.json
+++ b/Policies/Backup/vm-backup-without-tag/azurepolicy.json
@@ -1,0 +1,165 @@
+{
+  "mode": "indexed",
+  "parameters": {
+    "backupVaultResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "displayName": "Backup Vault Resource Group Name",
+        "description": "Resource Group in which the backup vault resides"
+      }
+    },
+    "backupVault": {
+      "type": "string",
+      "metadata": {
+        "displayName": "Backup Vault Name",
+        "description": "Target backup vault for VM backup onboarding"
+      }
+    },
+    "backupPolicy": {
+      "type": "string",
+      "metadata": {
+        "displayName": "backupPolicy",
+        "description": "Target backup policy for VM backup onboarding"
+      }
+    },
+    "exclusionTagName": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Exclusion Tag Name",
+        "description": "Name of the tag to use for excluding VMs from the scope of this policy. This should be used along with the Exclusion Tag Value parameter."
+      },
+      "defaultValue": "SkipBackup"
+    },
+    "exclusionTagValue": {
+      "type": "Array",
+      "metadata": {
+        "displayName": "Exclusion Tag Values",
+        "description": "Value of the tag to use for excluding VMs from the scope of this policy (in case of multiple values, use a comma-separated list). This should be used along with the Exclusion Tag Name parameter."
+      },
+      "defaultValue": [ "true", "yes" ]
+    }
+  },
+  "policyRule": {
+    "if": {
+      "allOf": [
+        {
+          "field": "type",
+          "equals": "Microsoft.Compute/virtualMachines"
+        },
+        {
+          "field": "id",
+          "notContains": "/resourceGroups/databricks-rg-"
+        },
+        {
+          "anyOf": [
+            {
+              "not": {
+                "field": "[concat('tags[', parameters('exclusionTagName'), ']')]",
+                "in": "[parameters('exclusionTagValue')]"
+              }
+            },
+            {
+              "value": "[empty(parameters('exclusionTagValue'))]",
+              "equals": "true"
+            },
+            {
+              "value": "[empty(parameters('exclusionTagName'))]",
+              "equals": "true"
+            }
+          ]
+        }
+      ]
+    },
+    "then": {
+      "effect": "deployIfNotExists",
+      "details": {
+        "roleDefinitionIds": [
+          "/providers/microsoft.authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c",
+          "/providers/microsoft.authorization/roleDefinitions/5e467623-bb1f-42f4-a55d-6e525e11384b"
+        ],
+        "type": "Microsoft.RecoveryServices/backupprotecteditems",
+        "existenceCondition": {
+          "allOf": [
+            {
+              "field": "name",
+              "like": "*"
+            }
+          ]
+        },
+        "deployment": {
+          "properties": {
+            "mode": "incremental",
+            "template": {
+              "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "vmName": {
+                  "type": "string"
+                },
+                "vmResourceGroup": {
+                  "type": "string"
+                },
+                "backupVaultResourceGroup": {
+                  "type": "string"
+                },
+                "backupVault": {
+                  "type": "string"
+                },
+                "backupPolicy": {
+                  "type": "string"
+                }
+              },
+              "variables": {
+                "backupIntentConcat": "[concat('/Azure/vm;iaasvmcontainerv2;',parameters('vmResourceGroup'),';',parameters('vmName'))]"
+              },
+              "resources": [
+                {
+                  "apiVersion": "2017-05-10",
+                  "name": "[concat(parameters('vmName'), '-' , 'backupIntent')]",
+                  "type": "Microsoft.Resources/deployments",
+                  "resourceGroup": "[parameters('backupVaultResourceGroup')]",
+                  "properties": {
+                    "mode": "Incremental",
+                    "template": {
+                      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                      "contentVersion": "1.0.0.0",
+                      "resources": [
+                        {
+                          "name": "[concat(parameters('backupVault'),variables('backupIntentConcat'))]",
+                          "apiVersion": "2017-07-01",
+                          "type": "Microsoft.RecoveryServices/vaults/backupFabrics/backupProtectionIntent",
+                          "properties": {
+                            "protectionIntentItemType": "AzureResourceItem",
+                            "policyId": "[concat(resourceId('Microsoft.RecoveryServices/vaults/backuppolicies',parameters('backupVault'),parameters('backupPolicy')))]",
+                            "sourceResourceId": "[concat(resourceId('Microsoft.Compute/virtualMachines',parameters('vmName')))]"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "parameters": {
+              "vmName": {
+                "value": "[field('name')]"
+              },
+              "vmResourceGroup": {
+                "value": "[resourcegroup().name]"
+              },
+              "backupVaultResourceGroup": {
+                "value": "[parameters('backupVaultResourceGroup')]"
+              },
+              "backupVault": {
+                "value": "[parameters('backupVault')]"
+              },
+              "backupPolicy": {
+                "value": "[parameters('backupPolicy')]"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/Backup/vm-backup-without-tag/azurepolicy.json
+++ b/Policies/Backup/vm-backup-without-tag/azurepolicy.json
@@ -36,7 +36,15 @@
         "displayName": "Exclusion Tag Values",
         "description": "Value of the tag to use for excluding VMs from the scope of this policy (in case of multiple values, use a comma-separated list). This should be used along with the Exclusion Tag Name parameter."
       },
-      "defaultValue": [ "true", "yes" ]
+      "defaultValue": ["true", "yes"]
+    },
+    "effect": {
+      "type": "string",
+      "metadata": {
+        "displayName": "Effect"
+      },
+      "allowedValues": ["deployIfNotExists", "disabled"],
+      "defaultValue": "deployIfNotExists"
     }
   },
   "policyRule": {
@@ -71,7 +79,7 @@
       ]
     },
     "then": {
-      "effect": "deployIfNotExists",
+      "effect": "[parameters('effect')]",
       "details": {
         "roleDefinitionIds": [
           "/providers/microsoft.authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c",

--- a/Policies/Backup/vm-backup-without-tag/azurepolicy.parameters.json
+++ b/Policies/Backup/vm-backup-without-tag/azurepolicy.parameters.json
@@ -34,9 +34,14 @@
       "displayName": "Exclusion Tag Values",
       "description": "Value of the tag to use for excluding VMs from the scope of this policy (in case of multiple values, use a comma-separated list). This should be used along with the Exclusion Tag Name parameter."
     },
-    "defaultValue": [
-      "true",
-      "yes"
-    ]
+    "defaultValue": ["true", "yes"]
+  },
+  "effect": {
+    "type": "string",
+    "metadata": {
+      "displayName": "Effect"
+    },
+    "allowedValues": ["deployIfNotExists", "disabled"],
+    "defaultValue": "deployIfNotExists"
   }
 }

--- a/Policies/Backup/vm-backup-without-tag/azurepolicy.parameters.json
+++ b/Policies/Backup/vm-backup-without-tag/azurepolicy.parameters.json
@@ -1,0 +1,42 @@
+{
+  "backupVaultResourceGroup": {
+    "type": "string",
+    "metadata": {
+      "displayName": "Backup Vault Resource Group Name",
+      "description": "Resource Group in which the backup vault resides"
+    }
+  },
+  "backupVault": {
+    "type": "string",
+    "metadata": {
+      "displayName": "Backup Vault Name",
+      "description": "Target backup vault for VM backup onboarding"
+    }
+  },
+  "backupPolicy": {
+    "type": "string",
+    "metadata": {
+      "displayName": "backupPolicy",
+      "description": "Target backup policy for VM backup onboarding"
+    }
+  },
+  "exclusionTagName": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Exclusion Tag Name",
+      "description": "Name of the tag to use for excluding VMs from the scope of this policy. This should be used along with the Exclusion Tag Value parameter."
+    },
+    "defaultValue": "SkipBackup"
+  },
+  "exclusionTagValue": {
+    "type": "Array",
+    "metadata": {
+      "displayName": "Exclusion Tag Values",
+      "description": "Value of the tag to use for excluding VMs from the scope of this policy (in case of multiple values, use a comma-separated list). This should be used along with the Exclusion Tag Name parameter."
+    },
+    "defaultValue": [
+      "true",
+      "yes"
+    ]
+  }
+}

--- a/Policies/Backup/vm-backup-without-tag/azurepolicy.rules.json
+++ b/Policies/Backup/vm-backup-without-tag/azurepolicy.rules.json
@@ -1,0 +1,123 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Compute/virtualMachines"
+      },
+      {
+        "field": "id",
+        "notContains": "/resourceGroups/databricks-rg-"
+      },
+      {
+        "anyOf": [
+          {
+            "not": {
+              "field": "[concat('tags[', parameters('exclusionTagName'), ']')]",
+              "in": "[parameters('exclusionTagValue')]"
+            }
+          },
+          {
+            "value": "[empty(parameters('exclusionTagValue'))]",
+            "equals": "true"
+          },
+          {
+            "value": "[empty(parameters('exclusionTagName'))]",
+            "equals": "true"
+          }
+        ]
+      }
+    ]
+  },
+  "then": {
+    "effect": "deployIfNotExists",
+    "details": {
+      "roleDefinitionIds": [
+        "/providers/microsoft.authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c",
+        "/providers/microsoft.authorization/roleDefinitions/5e467623-bb1f-42f4-a55d-6e525e11384b"
+      ],
+      "type": "Microsoft.RecoveryServices/backupprotecteditems",
+      "existenceCondition": {
+        "allOf": [
+          {
+            "field": "name",
+            "like": "*"
+          }
+        ]
+      },
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "vmName": {
+                "type": "string"
+              },
+              "vmResourceGroup": {
+                "type": "string"
+              },
+              "backupVaultResourceGroup": {
+                "type": "string"
+              },
+              "backupVault": {
+                "type": "string"
+              },
+              "backupPolicy": {
+                "type": "string"
+              }
+            },
+            "variables": {
+              "backupIntentConcat": "[concat('/Azure/vm;iaasvmcontainerv2;',parameters('vmResourceGroup'),';',parameters('vmName'))]"
+            },
+            "resources": [
+              {
+                "apiVersion": "2017-05-10",
+                "name": "[concat(parameters('vmName'), '-' , 'backupIntent')]",
+                "type": "Microsoft.Resources/deployments",
+                "resourceGroup": "[parameters('backupVaultResourceGroup')]",
+                "properties": {
+                  "mode": "Incremental",
+                  "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                      {
+                        "name": "[concat(parameters('backupVault'),variables('backupIntentConcat'))]",
+                        "apiVersion": "2017-07-01",
+                        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/backupProtectionIntent",
+                        "properties": {
+                          "protectionIntentItemType": "AzureResourceItem",
+                          "policyId": "[concat(resourceId('Microsoft.RecoveryServices/vaults/backuppolicies',parameters('backupVault'),parameters('backupPolicy')))]",
+                          "sourceResourceId": "[concat(resourceId('Microsoft.Compute/virtualMachines',parameters('vmName')))]"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "parameters": {
+            "vmName": {
+              "value": "[field('name')]"
+            },
+            "vmResourceGroup": {
+              "value": "[resourcegroup().name]"
+            },
+            "backupVaultResourceGroup": {
+              "value": "[parameters('backupVaultResourceGroup')]"
+            },
+            "backupVault": {
+              "value": "[parameters('backupVault')]"
+            },
+            "backupPolicy": {
+              "value": "[parameters('backupPolicy')]"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/Backup/vm-backup-without-tag/azurepolicy.rules.json
+++ b/Policies/Backup/vm-backup-without-tag/azurepolicy.rules.json
@@ -30,7 +30,7 @@
     ]
   },
   "then": {
-    "effect": "deployIfNotExists",
+    "effect": "[parameters('effect')]",
     "details": {
       "roleDefinitionIds": [
         "/providers/microsoft.authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c",


### PR DESCRIPTION
Policy to enable backup to an existing RSV in the same subscription. Option to skip vm's with spcified tag