### PR TITLE
Azure Functions built-in policies (for security baselines)

### DIFF
--- a/Policies/App Service/functionapp-deployed-to-appserviceenvironment/azurepolicy.json
+++ b/Policies/App Service/functionapp-deployed-to-appserviceenvironment/azurepolicy.json
@@ -1,0 +1,48 @@
+{
+    "properties": {
+      "displayName": "Function apps must be deployed to an App Service Environment (ASE)",
+      "policyType": "Custom",
+      "mode": "Indexed",
+      "description": "",
+      "metadata": {
+        "version": "1.0.0",
+        "category": "App Service"
+      },
+      "parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+          },
+          "allowedValues": [
+            "Audit",
+            "Deny",
+            "Disabled"
+          ],
+          "defaultValue": "Audit"
+        }
+      },
+      "policyRule": {
+        "if":  {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Web/sites"
+            },
+            {
+              "field": "kind",
+              "contains": "functionapp"
+            },
+            {
+                "field": "Microsoft.Web/sites/hostingEnvironmentProfile.id",
+                "exists": false
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]"
+        }
+      }
+    }
+}

--- a/Policies/App Service/functionapp-deployed-to-appserviceenvironment/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-deployed-to-appserviceenvironment/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Deny",
+      "Disabled"
+    ],
+    "defaultValue": "Audit"
+  }
+}

--- a/Policies/App Service/functionapp-deployed-to-appserviceenvironment/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-deployed-to-appserviceenvironment/azurepolicy.rules.json
@@ -1,0 +1,21 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      },
+      {
+        "field": "Microsoft.Web/sites/hostingEnvironmentProfile.id",
+        "exists": false
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/App Service/functionapp-disable-deployment-local-auth-ftp/functionapp-disable-deployment-local-auth-scm/azurepolicy.json
+++ b/Policies/App Service/functionapp-disable-deployment-local-auth-ftp/functionapp-disable-deployment-local-auth-scm/azurepolicy.json
@@ -1,0 +1,93 @@
+{
+    "properties": {
+      "displayName": "Function apps should have local authentication methods for deployment disabled",
+      "policyType": "Custom",
+      "mode": "Indexed",
+      "description": "Disabling local authentication methods improves security by ensuring that the app exclusively requires Azure Active Directory identities for authentication. Learn more at: https://aka.ms/app-service-disable-basic-auth.",
+      "metadata": {
+        "version": "1.0.0",
+        "category": "App Service"
+      },
+      "parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+          },
+          "allowedValues": [
+            "AuditIfNotExists",
+            "DeployIfNotExists",
+            "Disabled"
+          ],
+          "defaultValue": "AuditIfNotExists"
+        }
+      },
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Web/sites"
+            },
+            {
+              "field": "kind",
+              "contains": "functionapp"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]",
+          "details": {
+            "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+            "name": "ftp",
+            "existenceCondition": {
+              "field": "Microsoft.Web/sites/basicPublishingCredentialsPolicies/allow",
+              "equals": false
+            },
+            "roleDefinitionIds": [
+              "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+            ],
+            "deployment": {
+              "properties": {
+                "mode": "incremental",
+                "parameters": {
+                  "siteName": {
+                    "value": "[field('name')]"
+                  },
+                  "location": {
+                    "value": "[field('location')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {
+                    "siteName": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    }
+                  },
+                  "variables": {},
+                  "resources": [
+                    {
+                      "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+                      "name": "[concat(parameters('siteName'), '/ftp')]",
+                      "apiVersion": "2020-12-01",
+                      "location": "[parameters('location')]",
+                      "tags": {},
+                      "properties": {
+                        "allow": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/Policies/App Service/functionapp-disable-deployment-local-auth-ftp/functionapp-disable-deployment-local-auth-scm/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-disable-deployment-local-auth-ftp/functionapp-disable-deployment-local-auth-scm/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/Policies/App Service/functionapp-disable-deployment-local-auth-ftp/functionapp-disable-deployment-local-auth-scm/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-disable-deployment-local-auth-ftp/functionapp-disable-deployment-local-auth-scm/azurepolicy.rules.json
@@ -1,0 +1,66 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+      "name": "ftp",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/basicPublishingCredentialsPolicies/allow",
+        "equals": false
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "parameters": {
+            "siteName": {
+              "value": "[field('name')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "siteName": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              }
+            },
+            "variables": {},
+            "resources": [
+              {
+                "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+                "name": "[concat(parameters('siteName'), '/ftp')]",
+                "apiVersion": "2020-12-01",
+                "location": "[parameters('location')]",
+                "tags": {},
+                "properties": {
+                  "allow": false
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-disable-deployment-local-auth-scm/azurepolicy.json
+++ b/Policies/App Service/functionapp-disable-deployment-local-auth-scm/azurepolicy.json
@@ -1,0 +1,93 @@
+{
+    "properties": {
+      "displayName": "Function apps should have local authentication methods for deployment disabled",
+      "policyType": "Custom",
+      "mode": "Indexed",
+      "description": "Disabling local authentication methods improves security by ensuring that the app exclusively requires Azure Active Directory identities for authentication. Learn more at: https://aka.ms/app-service-disable-basic-auth.",
+      "metadata": {
+        "version": "1.0.0",
+        "category": "App Service"
+      },
+      "parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+          },
+          "allowedValues": [
+            "AuditIfNotExists",
+            "DeployIfNotExists",
+            "Disabled"
+          ],
+          "defaultValue": "AuditIfNotExists"
+        }
+      },
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Web/sites"
+            },
+            {
+              "field": "kind",
+              "contains": "functionapp"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]",
+          "details": {
+            "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+            "name": "scm",
+            "existenceCondition": {
+              "field": "Microsoft.Web/sites/basicPublishingCredentialsPolicies/allow",
+              "equals": false
+            },
+            "roleDefinitionIds": [
+              "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+            ],
+            "deployment": {
+              "properties": {
+                "mode": "incremental",
+                "parameters": {
+                  "siteName": {
+                    "value": "[field('name')]"
+                  },
+                  "location": {
+                    "value": "[field('location')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {
+                    "siteName": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    }
+                  },
+                  "variables": {},
+                  "resources": [
+                    {
+                      "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+                      "name": "[concat(parameters('siteName'), '/scm')]",
+                      "apiVersion": "2020-12-01",
+                      "location": "[parameters('location')]",
+                      "tags": {},
+                      "properties": {
+                        "allow": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/Policies/App Service/functionapp-disable-deployment-local-auth-scm/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-disable-deployment-local-auth-scm/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/Policies/App Service/functionapp-disable-deployment-local-auth-scm/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-disable-deployment-local-auth-scm/azurepolicy.rules.json
@@ -1,0 +1,66 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+      "name": "scm",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/basicPublishingCredentialsPolicies/allow",
+        "equals": false
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "parameters": {
+            "siteName": {
+              "value": "[field('name')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "siteName": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              }
+            },
+            "variables": {},
+            "resources": [
+              {
+                "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+                "name": "[concat(parameters('siteName'), '/scm')]",
+                "apiVersion": "2020-12-01",
+                "location": "[parameters('location')]",
+                "tags": {},
+                "properties": {
+                  "allow": false
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-enforce-client-certs-audit_or_deny/azurepolicy.json
+++ b/Policies/App Service/functionapp-enforce-client-certs-audit_or_deny/azurepolicy.json
@@ -1,0 +1,48 @@
+{
+    "properties": {
+      "displayName": "Function apps should have 'Client Certificates (Incoming client certificates)' enabled",
+      "policyType": "Custom",
+      "mode": "Indexed",
+      "description": "Client certificates allow for the app to request a certificate for incoming requests. Only clients with valid certificates will be able to reach the app.",
+      "metadata": {
+        "version": "1.0.1",
+        "category": "App Service"
+      },
+      "parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+          },
+          "allowedValues": [
+            "Audit",
+            "Deny",
+            "Disabled"
+          ],
+          "defaultValue": "Audit"
+        }
+      },
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Web/sites"
+            },
+            {
+              "field": "kind",
+              "contains": "functionapp"
+            },
+            {
+              "field": "Microsoft.Web/sites/clientCertEnabled",
+              "equals": false
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]"
+        }
+      }
+    }
+  }

--- a/Policies/App Service/functionapp-enforce-client-certs-audit_or_deny/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-enforce-client-certs-audit_or_deny/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Deny",
+      "Disabled"
+    ],
+    "defaultValue": "Audit"
+  }
+}

--- a/Policies/App Service/functionapp-enforce-client-certs-audit_or_deny/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-enforce-client-certs-audit_or_deny/azurepolicy.rules.json
@@ -1,0 +1,21 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      },
+      {
+        "field": "Microsoft.Web/sites/clientCertEnabled",
+        "equals": false
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/App Service/functionapp-enforce-client-certs-dine/azurepolicy.json
+++ b/Policies/App Service/functionapp-enforce-client-certs-dine/azurepolicy.json
@@ -1,0 +1,93 @@
+{
+    "properties": {
+      "displayName": "Function apps should have 'Client Certificates (Incoming client certificates)' enabled",
+      "policyType": "Custom",
+      "mode": "Indexed",
+      "description": "Client certificates allow for the app to request a certificate for incoming requests. Only clients with valid certificates will be able to reach the app.",
+      "metadata": {
+        "version": "1.0.1",
+        "category": "App Service"
+      },
+      "parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+          },
+          "allowedValues": [
+            "DeployIfNotExists",
+            "Disabled"
+          ],
+          "defaultValue": "DeployIfNotExists"
+        }
+      },
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Web/sites"
+            },
+            {
+              "field": "kind",
+              "contains": "functionapp"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]",
+          "details": {
+            "type": "Microsoft.Web/sites",
+            "name": "[field('name')]",
+            "existenceCondition": {
+                "field": "Microsoft.Web/sites/clientCertEnabled",
+                "equals": true
+            },
+            "evaluationDelay" : "AfterProvisioningSuccess",
+            "roleDefinitionIds": [
+                "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+            ],
+            "deployment": {
+                "properties": {
+                  "mode": "incremental",
+                  "parameters": {
+                    "name": {
+                        "value": "[field('name')]"
+                    },
+                    "location": {
+                        "value": "[field('location')]"
+
+                    }
+                  },
+                  "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "location": {
+                          "type": "string"
+                      }
+                    },
+                    "resources": [
+                      {
+                        "name": "[parameters('name')]",
+                        "type": "Microsoft.Web/sites",
+                        "location": "[parameters('location')]",
+                        "apiVersion": "2018-11-01",
+                        "properties": {
+                          "clientCertEnabled": true
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+
+        }
+        }
+      }
+    }
+  }

--- a/Policies/App Service/functionapp-enforce-client-certs-dine/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-enforce-client-certs-dine/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "DeployIfNotExists"
+  }
+}

--- a/Policies/App Service/functionapp-enforce-client-certs-dine/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-enforce-client-certs-dine/azurepolicy.rules.json
@@ -1,0 +1,65 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Web/sites",
+      "name": "[field('name')]",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/clientCertEnabled",
+        "equals": true
+      },
+      "evaluationDelay": "AfterProvisioningSuccess",
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "parameters": {
+            "name": {
+              "value": "[field('name')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "name": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              }
+            },
+            "resources": [
+              {
+                "name": "[parameters('name')]",
+                "type": "Microsoft.Web/sites",
+                "location": "[parameters('location')]",
+                "apiVersion": "2018-11-01",
+                "properties": {
+                  "clientCertEnabled": true
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-enforce-connect-to-acr-with-identity/azurepolicy.json
+++ b/Policies/App Service/functionapp-enforce-connect-to-acr-with-identity/azurepolicy.json
@@ -1,0 +1,93 @@
+{
+    "properties": {
+      "displayName": "Function apps should authenticate to Azure Container Registry using a managed identity",
+      "policyType": "Custom",
+      "mode": "Indexed",
+      "description": "Function apps should authenticate to Azure Container Registry using a managed identity",
+      "metadata": {
+        "version": "1.0.0",
+        "category": "App Service"
+      },
+      "parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+          },
+          "allowedValues": [
+            "AuditIfNotExists",
+            "DeployIfNotExists",
+            "Disabled"
+          ],
+          "defaultValue": "AuditIfNotExists"
+        }
+      },
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Web/sites"
+            },
+            {
+              "field": "kind",
+              "contains": "functionapp"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]",
+          "details": {
+            "type": "Microsoft.Web/sites/config",
+            "name": "web",
+            "existenceCondition": {
+              "field": "Microsoft.Web/sites/config/acrUseManagedIdentityCreds",
+              "equals": true
+            },
+            "roleDefinitionIds": [
+              "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+            ],
+            "deployment": {
+              "properties": {
+                "mode": "incremental",
+                "parameters": {
+                  "siteName": {
+                    "value": "[field('name')]"
+                  },
+                  "location": {
+                    "value": "[field('location')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {
+                    "siteName": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    }
+                  },
+                  "variables": {},
+                  "resources": [
+                    {
+                      "type": "Microsoft.Web/sites/config",
+                      "name": "[concat(parameters('siteName'), '/web')]",
+                      "apiVersion": "2021-02-01",
+                      "location": "[parameters('location')]",
+                      "tags": {},
+                      "properties": {
+                        "acrUseManagedIdentityCreds": true
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/Policies/App Service/functionapp-enforce-connect-to-acr-with-identity/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-enforce-connect-to-acr-with-identity/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/Policies/App Service/functionapp-enforce-connect-to-acr-with-identity/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-enforce-connect-to-acr-with-identity/azurepolicy.rules.json
@@ -1,0 +1,66 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Web/sites/config",
+      "name": "web",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/config/acrUseManagedIdentityCreds",
+        "equals": true
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "parameters": {
+            "siteName": {
+              "value": "[field('name')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "siteName": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              }
+            },
+            "variables": {},
+            "resources": [
+              {
+                "type": "Microsoft.Web/sites/config",
+                "name": "[concat(parameters('siteName'), '/web')]",
+                "apiVersion": "2021-02-01",
+                "location": "[parameters('location')]",
+                "tags": {},
+                "properties": {
+                  "acrUseManagedIdentityCreds": true
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-enforce-ftps-only/azurepolicy.json
+++ b/Policies/App Service/functionapp-enforce-ftps-only/azurepolicy.json
@@ -1,0 +1,105 @@
+{
+  "properties": {
+    "displayName": "Enforce FTPS only or disablement of FTP/FTPS for App Service and Azure Functions",
+    "policyType": "Custom",
+    "mode": "Indexed",
+    "description": "Enforce FTPS only or disablement of FTP/FTPS for App Service and Azure Functions",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "App Service"
+    },
+    "parameters": {
+      "effect": {
+        "type": "string",
+        "defaultValue": "AuditIfNotExists",
+        "allowedValues": [
+          "AuditIfNotExists",
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        }
+      },
+      "allowFTPS": {
+        "type": "boolean",
+        "defaultValue": false,
+        "metadata": {
+          "displayName": "Allow FTPS",
+          "description": "Allow FtpsOnly as a valid configuration. FTP will still be disabled."
+        }
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Web/sites"
+          },
+          {
+            "field": "kind",
+            "contains": "functionapp"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.Web/sites/config",
+          "name": "web",
+          "existenceCondition": {
+            "field": "Microsoft.Web/sites/config/ftpsState",
+            "in": "[if(parameters('allowFTPS'), createArray('FtpsOnly', 'Disabled'), createArray('Disabled'))]"
+          },
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+          ],
+          "deployment": {
+            "properties": {
+              "mode": "incremental",
+              "parameters": {
+                "name": {
+                  "value": "[field('name')]"
+                },
+                "allowFTPS": {
+                  "value": "[parameters('allowFTPS')]"
+                },
+                "location": {
+                  "value": "[field('location')]"
+                }
+              },
+              "template": {
+                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "allowFTPS": {
+                    "type": "bool"
+                  },
+                  "location": {
+                    "type": "string"
+                  }
+                },
+                "resources": [
+                  {
+                    "name": "[concat(parameters('name'), '/web')]",
+                    "type": "Microsoft.Web/sites/config",
+                    "location": "[parameters('location')]",
+                    "apiVersion": "2018-11-01",
+                    "properties": {
+                      "ftpsState": "[if(parameters('allowFTPS'), 'FtpsOnly', 'Disabled')]"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-enforce-ftps-only/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-enforce-ftps-only/azurepolicy.parameters.json
@@ -1,0 +1,23 @@
+{
+  "effect": {
+    "type": "string",
+    "defaultValue": "AuditIfNotExists",
+    "allowedValues": [
+      "AuditIfNotExists",
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    }
+  },
+  "allowFTPS": {
+    "type": "boolean",
+    "defaultValue": false,
+    "metadata": {
+      "displayName": "Allow FTPS",
+      "description": "Allow FtpsOnly as a valid configuration. FTP will still be disabled."
+    }
+  }
+}

--- a/Policies/App Service/functionapp-enforce-ftps-only/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-enforce-ftps-only/azurepolicy.rules.json
@@ -1,0 +1,70 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Web/sites/config",
+      "name": "web",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/config/ftpsState",
+        "in": "[if(parameters('allowFTPS'), createArray('FtpsOnly', 'Disabled'), createArray('Disabled'))]"
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "parameters": {
+            "name": {
+              "value": "[field('name')]"
+            },
+            "allowFTPS": {
+              "value": "[parameters('allowFTPS')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "name": {
+                "type": "string"
+              },
+              "allowFTPS": {
+                "type": "bool"
+              },
+              "location": {
+                "type": "string"
+              }
+            },
+            "resources": [
+              {
+                "name": "[concat(parameters('name'), '/web')]",
+                "type": "Microsoft.Web/sites/config",
+                "location": "[parameters('location')]",
+                "apiVersion": "2018-11-01",
+                "properties": {
+                  "ftpsState": "[if(parameters('allowFTPS'), 'FtpsOnly', 'Disabled')]"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-enforce-https-only-audit_or_deny/azurepolicy.json
+++ b/Policies/App Service/functionapp-enforce-https-only-audit_or_deny/azurepolicy.json
@@ -1,0 +1,48 @@
+{
+    "properties": {
+        "displayName": "Function App should only be accessible over HTTPS",
+        "policyType": "Custom",
+        "mode": "Indexed",
+        "description": "Use of HTTPS ensures server/service authentication and protects data in transit from network layer eavesdropping attacks.",
+        "metadata": {
+            "version": "1.0.0",
+            "category": "App Service"
+        },
+        "parameters": {
+            "effect": {
+                "type": "string",
+                "defaultValue": "Audit",
+                "allowedValues": [
+                    "Audit",
+                    "Deny",
+                    "Disabled"
+                ],
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "Enable or disable the execution of the policy"
+                }
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Web/sites"
+                    },
+                    {
+                        "field": "kind",
+                        "contains": "functionapp"
+                    },
+                    {
+                        "field": "Microsoft.Web/sites/httpsOnly",
+                        "notEquals": true
+                    }
+                ]
+            },
+            "then": {
+                "effect": "[parameters('effect')]"
+            }                
+        }
+    }
+}

--- a/Policies/App Service/functionapp-enforce-https-only-audit_or_deny/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-enforce-https-only-audit_or_deny/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "string",
+    "defaultValue": "Audit",
+    "allowedValues": [
+      "Audit",
+      "Deny",
+      "Disabled"
+    ],
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    }
+  }
+}

--- a/Policies/App Service/functionapp-enforce-https-only-audit_or_deny/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-enforce-https-only-audit_or_deny/azurepolicy.rules.json
@@ -1,0 +1,21 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      },
+      {
+        "field": "Microsoft.Web/sites/httpsOnly",
+        "notEquals": true
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/App Service/functionapp-enforce-https-only-dine/azurepolicy.json
+++ b/Policies/App Service/functionapp-enforce-https-only-dine/azurepolicy.json
@@ -1,0 +1,91 @@
+{
+    "properties": {
+        "displayName": "Function App should only be accessible over HTTPS",
+        "policyType": "Custom",
+        "mode": "Indexed",
+        "description": "Use of HTTPS ensures server/service authentication and protects data in transit from network layer eavesdropping attacks.",
+        "metadata": {
+            "version": "1.0.0",
+            "category": "App Service"
+        },
+        "parameters": {
+            "effect": {
+                "type": "string",
+                "defaultValue": "DeployIfNotExists",
+                "allowedValues": [
+                    "DeployIfNotExists",
+                    "Disabled"
+                ],
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "Enable or disable the execution of the policy"
+                }
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Web/sites"
+                    },
+                    {
+                        "field": "kind",
+                        "contains": "functionapp"
+                    }
+                ]
+            },
+            "then": {
+                "effect": "[parameters('effect')]",
+                "details": {
+                    "type": "Microsoft.Web/sites",
+                    "name": "[field('name')]",
+                    "existenceCondition": {
+                        "field": "Microsoft.Web/sites/httpsOnly",
+                        "equals": true
+                    },
+                    "evaluationDelay": "AfterProvisioningSuccess",
+                    "roleDefinitionIds": [
+                        "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+                    ],
+                    "deployment": {
+                        "properties": {
+                            "mode": "incremental",
+                            "parameters": {
+                                "name": {
+                                    "value": "[field('name')]"
+                                },
+                                "location": {
+                                    "value": "[field('location')]"
+                                }
+                            },
+                            "template": {
+                                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                                "contentVersion": "1.0.0.0",
+                                "parameters": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "location": {
+                                        "type": "string"
+                                    }
+                                },
+                                "resources": [
+                                    {
+                                        "name": "[parameters('name')]",
+                                        "type": "Microsoft.Web/sites",
+                                        "location": "[parameters('location')]",
+                                        "apiVersion": "2018-11-01",
+                                        "properties": {
+                                            "httpsOnly": true
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Policies/App Service/functionapp-enforce-https-only-dine/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-enforce-https-only-dine/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "string",
+    "defaultValue": "DeployIfNotExists",
+    "allowedValues": [
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    }
+  }
+}

--- a/Policies/App Service/functionapp-enforce-https-only-dine/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-enforce-https-only-dine/azurepolicy.rules.json
@@ -1,0 +1,65 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Web/sites",
+      "name": "[field('name')]",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/httpsOnly",
+        "equals": true
+      },
+      "evaluationDelay": "AfterProvisioningSuccess",
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "parameters": {
+            "name": {
+              "value": "[field('name')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "name": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              }
+            },
+            "resources": [
+              {
+                "name": "[parameters('name')]",
+                "type": "Microsoft.Web/sites",
+                "location": "[parameters('location')]",
+                "apiVersion": "2018-11-01",
+                "properties": {
+                  "httpsOnly": true
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-enforce-latest-tls/azurepolicy.json
+++ b/Policies/App Service/functionapp-enforce-latest-tls/azurepolicy.json
@@ -1,0 +1,84 @@
+{
+  "properties": {
+    "displayName": "Latest TLS version should be used in your Function App",
+    "policyType": "Custom",
+    "mode": "Indexed",
+    "description": "Upgrade to the latest TLS version",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "App Service"
+    },
+    "parameters": {
+      "effect": {
+        "type": "string",
+        "defaultValue": "AuditIfNotExists",
+        "allowedValues": [
+          "AuditIfNotExists",
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        }
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Web/sites"
+          },
+          {
+            "field": "kind",
+            "contains": "functionapp"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.Web/sites/config",
+          "name": "web",
+          "existenceCondition": {
+            "field": "Microsoft.Web/sites/config/minTlsVersion",
+            "equals": "1.2"
+          },
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+          ],
+          "deployment": {
+              "properties": {
+                "mode": "incremental",
+                "parameters": {
+                  "name": {
+                      "value": "[field('name')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "name": "[concat(parameters('name'), '/web')]",
+                      "type": "Microsoft.Web/sites/config",
+                      "apiVersion": "2018-11-01",
+                      "properties": {
+                        "minTlsVersion": "1.2"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-enforce-latest-tls/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-enforce-latest-tls/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "string",
+    "defaultValue": "AuditIfNotExists",
+    "allowedValues": [
+      "AuditIfNotExists",
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    }
+  }
+}

--- a/Policies/App Service/functionapp-enforce-latest-tls/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-enforce-latest-tls/azurepolicy.rules.json
@@ -1,0 +1,57 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Web/sites/config",
+      "name": "web",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/config/minTlsVersion",
+        "equals": "1.2"
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "parameters": {
+            "name": {
+              "value": "[field('name')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "resources": [
+              {
+                "name": "[concat(parameters('name'), '/web')]",
+                "type": "Microsoft.Web/sites/config",
+                "apiVersion": "2018-11-01",
+                "properties": {
+                  "minTlsVersion": "1.2"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-private-endpoints-enabled-aine/azurepolicy.json
+++ b/Policies/App Service/functionapp-private-endpoints-enabled-aine/azurepolicy.json
@@ -1,0 +1,50 @@
+{
+    "properties": {
+        "displayName": "Function apps must have private endpoints enabled",
+        "policyType": "Custom",
+        "mode": "Indexed",
+        "description": "A private endpoint connection enables private connectivity to your function app via a private IP address inside a virtual network. This configuration improves your security posture and supports Azure networking tools and scenarios.",
+        "metadata": {
+            "category": "App Service",
+            "version": "1.0.0"
+        },
+        "parameters": {
+            "effect": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "Enable or disable the execution of the policy"
+                },
+                "allowedValues": [
+                    "AuditIfNotExists",
+                    "Disabled"
+                ],
+                "defaultValue": "AuditIfNotExists"
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Web/sites"
+                    },
+                    {
+                        "field": "kind",
+                        "contains": "functionapp"
+                    }
+                ]
+            },
+            "then": {
+                "effect": "[parameters('effect')]",
+                "details": {
+                    "type": "Microsoft.Web/sites/privateEndpointConnections",
+                    "existenceCondition": {
+                        "field": "Microsoft.Web/sites/privateEndpointConnections/privateLinkServiceConnectionState.status",
+                        "equals": "Approved"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Policies/App Service/functionapp-private-endpoints-enabled-aine/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-private-endpoints-enabled-aine/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/Policies/App Service/functionapp-private-endpoints-enabled-aine/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-private-endpoints-enabled-aine/azurepolicy.rules.json
@@ -1,0 +1,24 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Web/sites/privateEndpointConnections",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/privateEndpointConnections/privateLinkServiceConnectionState.status",
+        "equals": "Approved"
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-private-endpoints-enabled-dine/azurepolicy.json
+++ b/Policies/App Service/functionapp-private-endpoints-enabled-dine/azurepolicy.json
@@ -1,0 +1,168 @@
+{
+    "properties": {
+        "displayName": "Function apps must have private endpoints enabled",
+        "policyType": "Custom",
+        "mode": "Indexed",
+        "description": "A private endpoint connection enables private connectivity to your function app via a private IP address inside a virtual network. This configuration improves your security posture and supports Azure networking tools and scenarios.",
+        "metadata": {
+            "category": "App Service",
+            "version": "1.0.0"
+        },
+        "parameters": {
+            "privateEndpointSubnetId": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Subnet to use for Private Endpoints",
+                    "description": "The name of the subnet within the virtual network that you would like to use for your Private Endpoint Connection deployment. Used by the DeployIfNotExists effect.",
+                    "strongType": "Microsoft.Network/virtualNetworks/subnets"
+                }
+            },
+            "effect": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "Enable or disable the execution of the policy"
+                },
+                "allowedValues": [
+                    "DeployIfNotExists",
+                    "Disabled"
+                ],
+                "defaultValue": "DeployIfNotExists"
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Web/sites"
+                    },
+                    {
+                        "field": "kind",
+                        "contains": "functionapp"
+                    }
+                ]
+            },
+            "then": {
+                "effect": "[parameters('effect')]",
+                "details": {
+                    "type": "Microsoft.Web/sites/privateEndpointConnections",
+                    "existenceCondition": {
+                        "field": "Microsoft.Web/sites/privateEndpointConnections/privateLinkServiceConnectionState.status",
+                        "equals": "Approved"
+                    },
+                    "roleDefinitionIds": [
+                        "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+                        "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+                    ],
+                    "deployment": {
+                        "properties": {
+                            "mode": "incremental",
+                            "parameters": {
+                                "name": {
+                                    "value": "[field('name')]"
+                                },
+                                "serviceId": {
+                                    "value": "[field('id')]"
+                                },
+                                "privateEndpointSubnetId": {
+                                    "value": "[parameters('privateEndpointSubnetId')]"
+                                }
+                            },
+                            "template": {
+                                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                "contentVersion": "1.0.0.0",
+                                "parameters": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "serviceId": {
+                                        "type": "string"
+                                    },
+                                    "privateEndpointSubnetId": {
+                                        "type": "string"
+                                    }
+                                },
+                                "variables": {
+                                    "privateEndpointName": "[concat('pe-',substring(parameters('name'),0,min(length(parameters('name')),50)),'-',uniquestring(deployment().name))]"
+                                },
+                                "resources": [
+                                    {
+                                        "type": "Microsoft.Resources/deployments",
+                                        "name": "[variables('privateEndpointName')]",
+                                        "apiVersion": "2020-06-01",
+                                        "properties": {
+                                            "mode": "Incremental",
+                                            "expressionEvaluationOptions": {
+                                                "scope": "inner"
+                                            },
+                                            "parameters": {
+                                                "name": {
+                                                    "value": "[parameters('name')]"
+                                                },
+                                                "privateEndpointSubnetId": {
+                                                    "value": "[parameters('privateEndpointSubnetId')]"
+                                                },
+                                                "serviceId": {
+                                                    "value": "[parameters('serviceId')]"
+                                                },
+                                                "subnetlocation": {
+                                                    "value": "[reference(first(take(split(parameters('privateEndpointSubnetId'),'/subnets'),1)),'2020-07-01','Full').location]"
+                                                }
+                                            },
+                                            "template": {
+                                                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                                "contentVersion": "1.0.0.0",
+                                                "parameters": {
+                                                    "name": {
+                                                        "type": "String"
+                                                    },
+                                                    "serviceId": {
+                                                        "type": "String"
+                                                    },
+                                                    "privateEndpointSubnetId": {
+                                                        "type": "String"
+                                                    },
+                                                    "subnetlocation": {
+                                                        "type": "String"
+                                                    }
+                                                },
+                                                "variables": {
+                                                    "privateEndpointName": "[deployment().name]"
+                                                },
+                                                "resources": [
+                                                    {
+                                                        "type": "Microsoft.Network/privateEndpoints",
+                                                        "apiVersion": "2020-07-01",
+                                                        "name": "[variables('privateEndpointName')]",
+                                                        "location": "[parameters('subnetlocation')]",
+                                                        "properties": {
+                                                            "subnet": {
+                                                                "id": "[parameters('privateEndpointSubnetId')]"
+                                                            },
+                                                            "privateLinkServiceConnections": [
+                                                                {
+                                                                    "name": "[parameters('name')]",
+                                                                    "properties": {
+                                                                        "privateLinkServiceId": "[parameters('serviceId')]",
+                                                                        "groupIds": [
+                                                                            "sites"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Policies/App Service/functionapp-private-endpoints-enabled-dine/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-private-endpoints-enabled-dine/azurepolicy.parameters.json
@@ -1,0 +1,22 @@
+{
+  "privateEndpointSubnetId": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Subnet to use for Private Endpoints",
+      "description": "The name of the subnet within the virtual network that you would like to use for your Private Endpoint Connection deployment. Used by the DeployIfNotExists effect.",
+      "strongType": "Microsoft.Network/virtualNetworks/subnets"
+    }
+  },
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "DeployIfNotExists"
+  }
+}

--- a/Policies/App Service/functionapp-private-endpoints-enabled-dine/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-private-endpoints-enabled-dine/azurepolicy.rules.json
@@ -1,0 +1,134 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Web/sites/privateEndpointConnections",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/privateEndpointConnections/privateLinkServiceConnectionState.status",
+        "equals": "Approved"
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+        "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "parameters": {
+            "name": {
+              "value": "[field('name')]"
+            },
+            "serviceId": {
+              "value": "[field('id')]"
+            },
+            "privateEndpointSubnetId": {
+              "value": "[parameters('privateEndpointSubnetId')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "name": {
+                "type": "string"
+              },
+              "serviceId": {
+                "type": "string"
+              },
+              "privateEndpointSubnetId": {
+                "type": "string"
+              }
+            },
+            "variables": {
+              "privateEndpointName": "[concat('pe-',substring(parameters('name'),0,min(length(parameters('name')),50)),'-',uniquestring(deployment().name))]"
+            },
+            "resources": [
+              {
+                "type": "Microsoft.Resources/deployments",
+                "name": "[variables('privateEndpointName')]",
+                "apiVersion": "2020-06-01",
+                "properties": {
+                  "mode": "Incremental",
+                  "expressionEvaluationOptions": {
+                    "scope": "inner"
+                  },
+                  "parameters": {
+                    "name": {
+                      "value": "[parameters('name')]"
+                    },
+                    "privateEndpointSubnetId": {
+                      "value": "[parameters('privateEndpointSubnetId')]"
+                    },
+                    "serviceId": {
+                      "value": "[parameters('serviceId')]"
+                    },
+                    "subnetlocation": {
+                      "value": "[reference(first(take(split(parameters('privateEndpointSubnetId'),'/subnets'),1)),'2020-07-01','Full').location]"
+                    }
+                  },
+                  "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                      "name": {
+                        "type": "String"
+                      },
+                      "serviceId": {
+                        "type": "String"
+                      },
+                      "privateEndpointSubnetId": {
+                        "type": "String"
+                      },
+                      "subnetlocation": {
+                        "type": "String"
+                      }
+                    },
+                    "variables": {
+                      "privateEndpointName": "[deployment().name]"
+                    },
+                    "resources": [
+                      {
+                        "type": "Microsoft.Network/privateEndpoints",
+                        "apiVersion": "2020-07-01",
+                        "name": "[variables('privateEndpointName')]",
+                        "location": "[parameters('subnetlocation')]",
+                        "properties": {
+                          "subnet": {
+                            "id": "[parameters('privateEndpointSubnetId')]"
+                          },
+                          "privateLinkServiceConnections": [
+                            {
+                              "name": "[parameters('name')]",
+                              "properties": {
+                                "privateLinkServiceId": "[parameters('serviceId')]",
+                                "groupIds": [
+                                  "sites"
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-pull-from-specified-registry/azurepolicy.json
+++ b/Policies/App Service/functionapp-pull-from-specified-registry/azurepolicy.json
@@ -1,0 +1,128 @@
+{
+    "properties": {
+        "displayName": "Linux function apps should only use a specified Azure Container Registry instance",
+        "policyType": "Custom",
+        "mode": "Indexed",
+        "description": "Ensure that Linux function apps can only pull custom images from a specified container registry",
+        "metadata": {
+            "version": "1.0.0",
+            "category": "App Service"
+        },
+        "parameters": {
+            "effect": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "Enable or disable the execution of the policy"
+                },
+                "allowedValues": [
+                    "AuditIfNotExists",
+                    "DeployIfNotExists",
+                    "Disabled"
+                ],
+                "defaultValue": "AuditIfNotExists"
+            },
+            "registryName": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Registry name",
+                    "description": "The name of the Azure Container Registry instance from which the function app is allowed to pull images."
+                }
+            },
+            "defaultRepositoryAndTag": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "DefaultRepositoryAndTag",
+                    "description": "A default image name for the application to use against the registry if this policy will deploy a remediation. A tag may optionally be specified by appending a ':' character and the tag name."
+                },
+                "defaultValue": "defaultSetByAzurePolicy"
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Web/sites"
+                    },
+                    {
+                        "field": "kind",
+                        "contains": "functionapp"
+                    }
+                ]
+            },
+            "then": {
+                "effect": "[parameters('effect')]",
+                "details": {
+                    "type": "Microsoft.Web/sites/config",
+                    "name": "web",
+                    "existenceCondition": {
+                        "anyOf": [
+                            {
+                                "field": "Microsoft.Web/sites/config/linuxFxVersion",
+                                "like": "[concat('DOCKER|',parameters('registryName'), '.azurecr.io/*')]"
+                            },
+                            {
+                                "field": "Microsoft.Web/sites/config/linuxFxVersion",
+                                "notLike": "DOCKER|*"
+                            }
+                        ]
+                    },
+                    "roleDefinitionIds": [
+                        "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+                    ],
+                    "deployment": {
+                        "properties": {
+                            "mode": "incremental",
+                            "parameters": {
+                                "siteName": {
+                                    "value": "[field('name')]"
+                                },
+                                "location": {
+                                    "value": "[field('location')]"
+                                },
+                                "defaultRepositoryAndTag": {
+                                    "value": "[parameters('defaultRepositoryAndTag')]"
+                                },
+                                "registryName": {
+                                    "value": "[parameters('registryName')]"
+                                }
+                            },
+                            "template": {
+                                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                "contentVersion": "1.0.0.0",
+                                "parameters": {
+                                    "siteName": {
+                                        "type": "string"
+                                    },
+                                    "location": {
+                                        "type": "string"
+                                    },
+                                    "registryName": {
+                                        "type": "string"
+                                    },
+                                    "defaultRepositoryAndTag": {
+                                        "type": "string"
+                                    }
+                                },
+                                "variables": {},
+                                "resources": [
+                                    {
+                                        "type": "Microsoft.Web/sites/config",
+                                        "name": "[concat(parameters('siteName'), '/web')]",
+                                        "apiVersion": "2021-02-01",
+                                        "location": "[parameters('location')]",
+                                        "tags": {},
+                                        "properties": {
+                                            "linuxFxVersion": "[concat('DOCKER|',parameters('registryName'), '.azurecr.io/', parameters('defaultRepositoryAndTag'))]"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Policies/App Service/functionapp-pull-from-specified-registry/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-pull-from-specified-registry/azurepolicy.parameters.json
@@ -1,0 +1,30 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  },
+  "registryName": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Registry name",
+      "description": "The name of the Azure Container Registry instance from which the function app is allowed to pull images."
+    }
+  },
+  "defaultRepositoryAndTag": {
+    "type": "String",
+    "metadata": {
+      "displayName": "DefaultRepositoryAndTag",
+      "description": "A default image name for the application to use against the registry if this policy will deploy a remediation. A tag may optionally be specified by appending a ':' character and the tag name."
+    },
+    "defaultValue": "defaultSetByAzurePolicy"
+  }
+}

--- a/Policies/App Service/functionapp-pull-from-specified-registry/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-pull-from-specified-registry/azurepolicy.rules.json
@@ -1,0 +1,86 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Web/sites/config",
+      "name": "web",
+      "existenceCondition": {
+        "anyOf": [
+          {
+            "field": "Microsoft.Web/sites/config/linuxFxVersion",
+            "like": "[concat('DOCKER|',parameters('registryName'), '.azurecr.io/*')]"
+          },
+          {
+            "field": "Microsoft.Web/sites/config/linuxFxVersion",
+            "notLike": "DOCKER|*"
+          }
+        ]
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "parameters": {
+            "siteName": {
+              "value": "[field('name')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            },
+            "defaultRepositoryAndTag": {
+              "value": "[parameters('defaultRepositoryAndTag')]"
+            },
+            "registryName": {
+              "value": "[parameters('registryName')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "siteName": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              },
+              "registryName": {
+                "type": "string"
+              },
+              "defaultRepositoryAndTag": {
+                "type": "string"
+              }
+            },
+            "variables": {},
+            "resources": [
+              {
+                "type": "Microsoft.Web/sites/config",
+                "name": "[concat(parameters('siteName'), '/web')]",
+                "apiVersion": "2021-02-01",
+                "location": "[parameters('location')]",
+                "tags": {},
+                "properties": {
+                  "linuxFxVersion": "[concat('DOCKER|',parameters('registryName'), '.azurecr.io/', parameters('defaultRepositoryAndTag'))]"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-vnet-injection-enabled/azurepolicy.json
+++ b/Policies/App Service/functionapp-vnet-injection-enabled/azurepolicy.json
@@ -1,0 +1,51 @@
+{
+    "properties": {
+      "displayName": "Function apps should be injected into a virtual network",
+      "policyType": "Custom",
+      "mode": "Indexed",
+      "description": "Injecting function apps in a virtual network unlocks advanced App Service networking and security features and provides you with greater control over your network security configuration. Learn more at: https://docs.microsoft.com/azure/app-service/web-sites-integrate-with-vnet.",
+      "metadata": {
+        "version": "1.0.0",
+        "category": "App Service"
+      },
+      "parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+          },
+          "allowedValues": [
+            "AuditIfNotExists",
+            "Disabled"
+          ],
+          "defaultValue": "AuditIfNotExists"
+        }
+      },
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Web/sites"
+            },
+            {
+              "field": "kind",
+              "contains": "functionapp"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]",
+          "details": {
+            "type": "Microsoft.Web/sites/networkConfig",
+            "name": "virtualNetwork",
+            "existenceCondition": {
+              "field": "Microsoft.Web/sites/networkConfig/subnetResourceId",
+              "notEquals": ""
+            }
+        }
+      }
+    }
+  }
+}

--- a/Policies/App Service/functionapp-vnet-injection-enabled/azurepolicy.parameters.json
+++ b/Policies/App Service/functionapp-vnet-injection-enabled/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/Policies/App Service/functionapp-vnet-injection-enabled/azurepolicy.rules.json
+++ b/Policies/App Service/functionapp-vnet-injection-enabled/azurepolicy.rules.json
@@ -1,0 +1,25 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "contains": "functionapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Web/sites/networkConfig",
+      "name": "virtualNetwork",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/networkConfig/subnetResourceId",
+        "notEquals": ""
+      }
+    }
+  }
+}


### PR DESCRIPTION

This PR is to add a collection of Azure Functions policies, in support of the [security baseline for Azure Functions](https://docs.microsoft.com/security/benchmark/azure/baselines/functions-security-baseline?toc=/azure/azure-functions/TOC.json). Each policy is represented by a separate commit.

The intent is for these to be built-in policies. Per the instructions I found on the [built-in policy repo](https://github.com/Azure/azure-policy), I am submitting the PR here since it won't be accepted here. **I am seeking guidance on any additional process needed here.** I am a member of the Functions team if we do need to handle anything internally.

Some of these are variants or modifications of existing built-in policies, which is where I have the most questions regarding process. I have attempted to capture the mapping below as best as I can. Notably, all condition references to the `kind` property have been moved from `"like": "functionapp*"` to `"contains": "functionapp"` to ensure that all function apps are actually captured; the existing version can be circumvented as ordering within the `kind` property is not guaranteed. I assert that in taking these to the built-in policy set, we should also update all existing Functions policies.

Also, I found out there are only two aliases marked as modifiable in the entirety of Microsoft.Web, and those are both single booleans on a child resource. That's why there are some audit/deny/deployIfNotExists combinations in here where the deployIfNotExists targets the resource itself to act _kind of_ like a modify effect. I also threw in an `"evaluationDelay": "AfterProvisioningSuccess",` for those to attempt to make it more like Modify, though I'm not sure if that's correct.

## Included policies

### Functions must use an App Service Environment (ASE)

Commit ID: de9618676044a8c3dcc94d2bcc761316d05c0da8

- Effects:
  - audit
  - deny

### Functions must have private endpoints enabled

Commit ID: 13e007aebc529647d9c749dd16cadefa8d56e9de

- Effects:
  - auditIfNotExists
- Inspired by (but not a modification of):
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppService_PrivateEndpoint_AINE.json

Commit ID: c51ed19459c860195e537e0f7d21f4561700f1b8

- Effects:
  - deployIfNotExists
- Inspired by (but not a modification of):
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppService_PrivateEndpoint_AINE.json
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/SQL/SqlServer_PrivateEndpoint_DeployIfNotExists.json

### Functions must have virtual network injection enabled  

Commit ID: f4912bc2c1114241f081ade769bd7193f81ac592

- Effects:
  - auditIfNotExists
- Inspired by (but not a modification of):
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppService_App_VNetIntegrationEnabled_Audit.json

### Enforce AAD only authentication for Functions deployments (disable local auth)

Commit ID: de0ada68e0e4d659eb2524fba067801f1533cad7

- Effects:
  - auditIfNotExists
  - deployIfNotExists
- Inspired by (but not a modification of):
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppService_FTP_BasicAuthEnabled_AuditIfNotExists.json
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppService_FTP_DisableBasicAuth_DeployIfNotExists.json

Commit ID: 0b293fe878965d22f641bc3bee2dc0ee961d20ba

- Effects:
  - auditIfNotExists
  - deployIfNotExists
- Inspired by (but not a modification of):
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppService_SCM_BasicAuthEnabled_AuditIfNotExists.json
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppService_SCM_DisableBasicAuth_DeployIfNotExists.json

### Enforce FTPS only on Functions

Commit ID: 6697b82c21e39fdf45edf9e9cec82e31afc23716

- Effects:
  - auditIfNotExists
  - deployIfNotExists
- Modifies built-in policies:
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppService_AuditFTPS_FunctionApp_Audit.json

### Enforce latest TLS version to be used on your function app

Commit ID: a88a27746bdb8f6b9f61b08e1029eb453398d1c8

- Effects:
  - auditIfNotExists
  - deployIfNotExists
- Modifies built-in policies:
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppService_RequireLatestTls_FunctionApp_Audit.json

### Function app should only be accessible via HTTPS

Commit ID: 579e5abb8ce8ac9b4fe14711ef0915f6ed93012b

- Effects:
  - audit
  - deny
- Modifies built-in policies:
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppServiceFunctionApp_AuditHTTP_Audit.json

Commit ID: 76596b241560fee23d07e32a9f8d2dc49a242327

- Effects:
  - deployIfNotExists
- Inspired by (but not a modification of):
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppServiceFunctionApp_AuditHTTP_Audit.json

### Ensure function app has 'Client Certifications' set to 'On'  

Commit ID: 07302a6116f0901be44d7abc6a7a0d6c5036605e

- Effects:
  - audit
  - deny
- Modifies built-in policies:
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppService_FunctionApp_Audit_ClientCert.json

Commit ID: e5c0fb61d8df2c12486952585170fd7b9b20af17

- Effects:
  - deployIfNotExists
- Inspired by (but not a modification of):
  - https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/App%20Service/AppService_FunctionApp_Audit_ClientCert.json

### Enforce function apps authenticate to Azure Container Registry using a Managed Identity

Commit ID: c14b8126ca4ff3e08be464e8a97fb98647d529df

- Effects:
  - auditIfNotExists
  - deployIfNotExists

### Enforce that function apps only can use a specified Azure Container Registry for images.

Commit ID: bf1a1c91df5cd7d4905deda22d1798a61e18e96a

- Effects:
  - auditIfNotExists
  - deployIfNotExists