### PR TITLE
Disk SKU policy update

### DIFF
--- a/Policies/Compute/allowed-disk-skus/azurepolicy.json
+++ b/Policies/Compute/allowed-disk-skus/azurepolicy.json
@@ -30,7 +30,7 @@
                     "equals": "Microsoft.Compute/disks"
                 },
                 {
-                    "field": "Microsoft.Compute/disk/sku.name",
+                    "field": "Microsoft.Compute/disks/sku.name",
                     "NotIn": "[parameters('allowedDiskSkus')]"
                 }
             ]

--- a/Policies/Compute/allowed-disk-skus/azurepolicy.rules.json
+++ b/Policies/Compute/allowed-disk-skus/azurepolicy.rules.json
@@ -6,7 +6,7 @@
                 "equals": "Microsoft.Compute/disks"
             },
             {
-                "field": "Microsoft.Compute/disk/sku.name",
+                "field": "Microsoft.Compute/disks/sku.name",
                 "NotIn": "[parameters('allowedDiskSkus')]"
             }
         ]


### PR DESCRIPTION
Updating the resource type from 'disk' to 'disks' as per the documentation to fix the error displayed below:

Status Message: The policy definition '[Custom] Allowed Disk Skus' rule is invalid. The resource type 'disk'
'Microsoft.Compute'. (Code:InvalidResourceTypeInPolicyAlias)