### PR TITLE
Replaced Private endpoint subnet index with last() function

### DIFF
--- a/Policies/Network/deny-private-endpoint-in-specific-subnets-based-on-naming-convention/azurepolicy.json
+++ b/Policies/Network/deny-private-endpoint-in-specific-subnets-based-on-naming-convention/azurepolicy.json
@@ -10,7 +10,7 @@
                     "equals": "Microsoft.Network/privateEndpoints"
                 },
                 {
-                    "value": "[split(field('Microsoft.Network/privateEndpoints/subnet.id'), '/')[10]]",
+                    "value": "[last(split(field('Microsoft.Network/privateEndpoints/subnet.id'), '/'))]",
                     "contains": "[parameters('subnetNamingConvention')]"
                 }
             ]

--- a/Policies/Network/deny-private-endpoint-in-specific-subnets-based-on-naming-convention/azurepolicy.rules.json
+++ b/Policies/Network/deny-private-endpoint-in-specific-subnets-based-on-naming-convention/azurepolicy.rules.json
@@ -6,7 +6,7 @@
                 "equals": "Microsoft.Network/privateEndpoints"
             },
             {
-                "value": "[split(field('Microsoft.Network/privateEndpoints/subnet.id'), '/')[10]]",
+                "value": "[last(split(field('Microsoft.Network/privateEndpoints/subnet.id'), '/'))]",
                 "contains": "[parameters('subnetNamingConvention')]"
             }
         ]


### PR DESCRIPTION
Just a small improvement where the [last()](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-array#last) function is used instead of using indexing to get the subnet name.