### PR TITLE
Fixed a JSON issue in deny-http-for-apps-force-https policy parameter…

### DIFF
--- a/Policies/WebApps/deny-http-for-apps-force-https/azurepolicy.parameters.json
+++ b/Policies/WebApps/deny-http-for-apps-force-https/azurepolicy.parameters.json
@@ -11,3 +11,4 @@
       ],
       "defaultValue": "Deny"
     }
+}


### PR DESCRIPTION
WebApp's deny-http-for-apps-force-https policy is missing a closing brace in its parameter file. 
This causes a JSON parsing issue when adding the policy definition.
Error:
json.decoder.JSONDecodeError: Expecting ',' delimiter: line 13 column 6 (char 290)

Fixed this issue by adding a closing brace to azurepolicy.parameters.json file in the deny-http-for-apps-force-https policy.
