### PR TITLE
New Policy: Deny Network Interface from joining an Application Security Group (ASG) if it is in a different Resource Group

### DIFF
--- a/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/README.md
+++ b/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/README.md
@@ -19,7 +19,7 @@ Sample parameter ```effect```, which can be used during policy assignment:
 
 ```powershell
 $definition = New-AzPolicyDefinition `
-    -Name "deny-pe-if-not-in-subnet" `
+    -Name "deny-nic-asg-join-if-not-same-rg" `
     -Policy 'https://raw.githubusercontent.com/ahmadabdalla/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.rules.json' `
     -Parameter 'https://raw.githubusercontent.com/ahmadabdalla/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.parameters.json' `
     -Mode All
@@ -27,8 +27,7 @@ $definition = New-AzPolicyDefinition `
 $definition
 
 $policyParameterObject = @{
-    "subnetName" = "pe"
-    "exemptedGroupIds"=@("table")
+    "effect" = "deny"
 }
 
 $assignment = New-AzPolicyAssignment `

--- a/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/README.md
+++ b/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/README.md
@@ -1,0 +1,55 @@
+# Deny NICs joining an ASG if in a different Resource Group
+
+This policy prevents users from trying to join a Virtual Machine's Network Interface to an Application Security Group (ASG) that exists in another Resource Group. The reason is that some ASGs are used in Network Security Group (NSG) rules, which could potentially allow VMs to have access to endpoints they shouldn't have access to. 
+
+## Try on Portal
+
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeny-nics-joining-asg-outside-of-same-resource-group%2Fazurepolicy.json)
+
+[![Deploy to Azure Gov](https://docs.microsoft.com/ahmadabdalla/governance/policy/media/deploy/deployGovbutton.png)](https://portal.azure.us/?#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeny-nics-joining-asg-outside-of-same-resource-group%2Fazurepolicy.json)
+
+Sample parameter ```effect```, which can be used during policy assignment:
+```json
+{
+    "effect": "deny"
+}
+```
+
+## Try with PowerShell
+
+```powershell
+$definition = New-AzPolicyDefinition `
+    -Name "deny-pe-if-not-in-subnet" `
+    -Policy 'https://raw.githubusercontent.com/ahmadabdalla/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.rules.json' `
+    -Parameter 'https://raw.githubusercontent.com/ahmadabdalla/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.parameters.json' `
+    -Mode All
+
+$definition
+
+$policyParameterObject = @{
+    "subnetName" = "pe"
+    "exemptedGroupIds"=@("table")
+}
+
+$assignment = New-AzPolicyAssignment `
+    -Name <assignmentname> `
+    -Scope <scope> `
+    -PolicyDefinition $definition `
+    -AssignIdentity `
+    -Location <location> `
+    -PolicyParameterObject $policyParameterObject
+
+$assignment
+```
+
+## Try with CLI
+
+```sh
+az policy definition create \
+    --name 'deny-nics-joining-asg-outside-of-same-resource-group' \
+    --rules 'https://raw.githubusercontent.com/ahmadabdalla/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.rules.json' \
+    --params 'https://raw.githubusercontent.com/ahmadabdalla/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.parameters.json' \
+    --mode All
+
+az policy assignment create --name <assignmentname> --scope <scope> --policy 'deny-nics-joining-asg-outside-of-same-resource-group' --location <location> --params '{"effect":{"value":"deny"}}'
+```

--- a/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/README.md
+++ b/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/README.md
@@ -4,9 +4,9 @@ This policy prevents users from trying to join a Virtual Machine's Network Inter
 
 ## Try on Portal
 
-[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fahmadabdalla%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeny-nics-joining-asg-outside-of-same-resource-group%2Fazurepolicy.json)
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeny-nics-joining-asg-outside-of-same-resource-group%2Fazurepolicy.json)
 
-[![Deploy to Azure Gov](https://docs.microsoft.com/azure/governance/policy/media/deploy/deployGovbutton.png)](https://portal.azure.us/?#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fahmadabdalla%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeny-nics-joining-asg-outside-of-same-resource-group%2Fazurepolicy.json)
+[![Deploy to Azure Gov](https://docs.microsoft.com/azure/governance/policy/media/deploy/deployGovbutton.png)](https://portal.azure.us/?#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeny-nics-joining-asg-outside-of-same-resource-group%2Fazurepolicy.json)
 
 Sample parameter ```effect```, which can be used during policy assignment:
 ```json
@@ -20,8 +20,8 @@ Sample parameter ```effect```, which can be used during policy assignment:
 ```powershell
 $definition = New-AzPolicyDefinition `
     -Name "deny-nic-asg-join-if-not-same-rg" `
-    -Policy 'https://raw.githubusercontent.com/ahmadabdalla/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.rules.json' `
-    -Parameter 'https://raw.githubusercontent.com/ahmadabdalla/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.parameters.json' `
+    -Policy 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.rules.json' `
+    -Parameter 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.parameters.json' `
     -Mode All
 
 $definition
@@ -31,11 +31,11 @@ $policyParameterObject = @{
 }
 
 $assignment = New-AzPolicyAssignment `
-    -Name <assignmentname> `
-    -Scope <scope> `
+    -Name 'policyAss' `
+    -Scope '/subscriptions/20d6fbfe-b049-471c-95af-1369d14d0d45' `
     -PolicyDefinition $definition `
     -AssignIdentity `
-    -Location <location> `
+    -Location 'australiaeast' `
     -PolicyParameterObject $policyParameterObject
 
 $assignment
@@ -46,8 +46,8 @@ $assignment
 ```sh
 az policy definition create \
     --name 'deny-nics-joining-asg-outside-of-same-resource-group' \
-    --rules 'https://raw.githubusercontent.com/ahmadabdalla/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.rules.json' \
-    --params 'https://raw.githubusercontent.com/ahmadabdalla/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.parameters.json' \
+    --rules 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.rules.json' \
+    --params 'https://raw.githubusercontent.com/Azure/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.parameters.json' \
     --mode All
 
 az policy assignment create --name <assignmentname> --scope <scope> --policy 'deny-nics-joining-asg-outside-of-same-resource-group' --location <location> --params '{"effect":{"value":"Deny"}}'

--- a/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/README.md
+++ b/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/README.md
@@ -4,14 +4,14 @@ This policy prevents users from trying to join a Virtual Machine's Network Inter
 
 ## Try on Portal
 
-[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeny-nics-joining-asg-outside-of-same-resource-group%2Fazurepolicy.json)
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fahmadabdalla%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeny-nics-joining-asg-outside-of-same-resource-group%2Fazurepolicy.json)
 
-[![Deploy to Azure Gov](https://docs.microsoft.com/ahmadabdalla/governance/policy/media/deploy/deployGovbutton.png)](https://portal.azure.us/?#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeny-nics-joining-asg-outside-of-same-resource-group%2Fazurepolicy.json)
+[![Deploy to Azure Gov](https://docs.microsoft.com/azure/governance/policy/media/deploy/deployGovbutton.png)](https://portal.azure.us/?#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fahmadabdalla%2FCommunity-Policy%2Fmaster%2FPolicies%2FNetwork%2Fdeny-nics-joining-asg-outside-of-same-resource-group%2Fazurepolicy.json)
 
 Sample parameter ```effect```, which can be used during policy assignment:
 ```json
 {
-    "effect": "deny"
+    "effect": "Deny"
 }
 ```
 
@@ -27,7 +27,7 @@ $definition = New-AzPolicyDefinition `
 $definition
 
 $policyParameterObject = @{
-    "effect" = "deny"
+    "effect" = "Deny"
 }
 
 $assignment = New-AzPolicyAssignment `
@@ -50,5 +50,5 @@ az policy definition create \
     --params 'https://raw.githubusercontent.com/ahmadabdalla/Community-Policy/master/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.parameters.json' \
     --mode All
 
-az policy assignment create --name <assignmentname> --scope <scope> --policy 'deny-nics-joining-asg-outside-of-same-resource-group' --location <location> --params '{"effect":{"value":"deny"}}'
+az policy assignment create --name <assignmentname> --scope <scope> --policy 'deny-nics-joining-asg-outside-of-same-resource-group' --location <location> --params '{"effect":{"value":"Deny"}}'
 ```

--- a/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.json
+++ b/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.json
@@ -1,0 +1,42 @@
+{
+    "mode": "All",
+    "name": "Deny NICs joining an ASG if in a different Resource Group",
+    "description": "This policy will deny an Network Interface from joining an Application Security Group, if they are in different Resource Groups.",
+    "policyRule": {
+        "if": {
+            "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.Network/networkInterfaces"
+                },
+                {
+                    "count": {
+                        "field": "Microsoft.Network/networkInterfaces/ipconfigurations[*].applicationSecurityGroups[*]",
+                        "where": {
+                            "field": "Microsoft.Network/networkInterfaces/ipconfigurations[*].applicationSecurityGroups[*].id",
+                            "notContains": "[resourceGroup().id]"
+                        }
+                    },
+                    "notEquals": 0
+                }
+            ]
+        },
+        "then": {
+            "effect": "[parameters('effect')]"
+        }
+    },
+    "parameters": {
+        "effect": {
+            "type": "String",
+            "metadata": {
+                "displayName": "Effect",
+                "description": "Enable or disable the execution of the policy"
+            },
+            "allowedValues": [
+                "Deny",
+                "Disabled"
+            ],
+            "defaultValue": "Deny"
+        }
+    }
+}

--- a/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.parameters.json
+++ b/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+    "effect": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+            "Deny",
+            "Disabled"
+        ],
+        "defaultValue": "Deny"
+    }
+}

--- a/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.rules.json
+++ b/Policies/Network/deny-nics-joining-asg-outside-of-same-resource-group/azurepolicy.rules.json
@@ -1,0 +1,23 @@
+{
+    "if": {
+        "allOf": [
+            {
+                "field": "type",
+                "equals": "Microsoft.Network/networkInterfaces"
+            },
+            {
+                "count": {
+                    "field": "Microsoft.Network/networkInterfaces/ipconfigurations[*].applicationSecurityGroups[*]",
+                    "where": {
+                        "field": "Microsoft.Network/networkInterfaces/ipconfigurations[*].applicationSecurityGroups[*].id",
+                        "notContains": "[resourceGroup().id]"
+                    }
+                },
+                "notEquals": 0
+            }
+        ]
+    },
+    "then": {
+        "effect": "[parameters('effect')]"
+    }
+}


### PR DESCRIPTION
New Policy: Deny Network Interface from joining an Application Security Group (ASG) if it is in a different Resource Group

In some or most scenarios, ASGs live within the same Resource Group where VMs (Network Interface) is deployed. If a VM NIC is allowed to join an ASG from another Resource Group, it can leverage the NSG rules that are allowed for the other ASG, which grants it network access to other resources it shouldn't. This policy ensures that a VM can only use an ASG within the same Resource Group.