### PR TITLE
deploy aadlogin ext for vm servers

### DIFF
--- a/Policies/Compute/[Preview] Deploy AAD Login For Linux SSH extension on Linux virtual machines/README.md
+++ b/Policies/Compute/[Preview] Deploy AAD Login For Linux SSH extension on Linux virtual machines/README.md
@@ -1,0 +1,18 @@
+# Deploy AAD login for Linux SSH extension on Linux virtual machines
+Author: Nathan Swift
+
+This policy deploys AAD login for Linux SSH extension on Linux virtual machines and sets the VM with MSI.
+
+# Contributing
+
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments. 

--- a/Policies/Compute/[Preview] Deploy AAD Login For Linux SSH extension on Linux virtual machines/deploy-aadlogin.json
+++ b/Policies/Compute/[Preview] Deploy AAD Login For Linux SSH extension on Linux virtual machines/deploy-aadlogin.json
@@ -1,0 +1,337 @@
+{
+    "mode": "Indexed",
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Compute/virtualMachines"
+          },
+          {
+            "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
+            "like": "linux*"
+          },
+          {
+            "anyOf": [
+              {
+                "not": {
+                  "field": "Microsoft.Compute/virtualMachines/imagePublisher",
+                  "in": "[parameters('PublishersToExclude')]"
+                }
+              },
+              {
+                "value": "[empty(parameters('PublishersToExclude'))]",
+                "equals": "true"
+              }
+            ]
+          },
+          {
+            "anyOf": [
+              {
+                "not": {
+                  "field": "Microsoft.Compute/virtualMachines/storageProfile.imageReference.id",
+                  "in": "[parameters('ImageIdsToExclude')]"
+                }
+              },
+              {
+                "value": "[empty(parameters('ImageIdsToExclude'))]",
+                "equals": "true"
+              }
+            ]
+          },
+          {
+            "anyOf": [
+              {
+                "not": {
+                  "field": "Microsoft.Compute/imagePublisher",
+                  "in": [
+                    "AzureDatabricks",
+                    "azureopenshift",
+                    "cisco",
+                    "fortinet",
+                    "juniper-networks",
+                    "barracudanetworks",
+                    "checkpoint",
+                    "imperva",
+                    "qualysguard",
+                    "f5-networks",
+                    "paloaltonetworks",
+                    "rohdeschwarzcybersecuritysas",
+                    "sonicwall-inc",
+                    "esdenera",
+                    "brocade_communications",
+                    "5nine-software-inc",
+                    "forcepoint-llc",
+                    "hillstone-networks",
+                    "netgate",
+                    "microsoft-aks"
+                  ]
+                }
+              },
+              {
+                "not": {
+                  "field": "Microsoft.Compute/imageOffer",
+                  "contains": "firewall"
+                }
+              },
+              {
+                "not": {
+                  "field": "Microsoft.Compute/imageSKU",
+                  "Like": "centos-6*"
+                }
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "cloudera"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "contains": "6"
+                    }
+                  ]
+                }
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "equals": "CentOS"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "Like": "6*"
+                    }
+                  ]
+                }
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "Like": "RHEL"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "Like": "6*"
+                    }
+                  ]
+                }
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "Like": "UbuntuServer"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "Like": "12*"
+                    }
+                  ]
+                }
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "Like": "UbuntuServer"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "Like": "14*"
+                    }
+                  ]
+                }
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "Like": "RightImage-Ubuntu"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "Like": "14*"
+                    }
+                  ]
+                }
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "Like": "RightImage-Ubuntu"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "Like": "12*"
+                    }
+                  ]
+                }
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "Like": "Debian*"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "Like": "8*"
+                    }
+                  ]
+                }
+              },
+              {
+                "not": {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Compute/imageOffer",
+                      "Like": "Oracle-Linux*"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "contains": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "roleDefinitionIds": [
+            "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+          ],
+          "type": "Microsoft.Compute/virtualMachines/extensions",
+          "name": "AADSSHLoginForLinux",
+          "existenceCondition": {
+            "allOf": [
+              {
+                "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+                "equals": "Microsoft.Azure.ActiveDirectory"
+              },
+              {
+                "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                "equals": "AADSSHLoginForLinux"
+              },
+              {
+                "field": "Microsoft.Compute/virtualMachines/extensions/provisioningState",
+                "equals": "Succeeded"
+              }
+            ]
+          },
+          "deployment": {
+            "properties": {
+              "mode": "incremental",
+              "parameters": {
+                "vmName": {
+                  "value": "[field('name')]"
+                },
+                "vmNamemsi": {
+                  "value": "[field('name')]"
+                },
+                "location": {
+                  "value": "[field('location')]"
+                },
+                "locationmsi": {
+                  "value": "[field('location')]"
+                },
+                "azureResourceId": {
+                  "value": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/',field('name'))]"
+                }
+              },
+              "template": {
+                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {
+                  "vmName": {
+                    "type": "string"
+                  },
+                  "vmNamemsi": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "locationmsi": {
+                    "type": "string"
+                  },
+                  "azureResourceId": {
+                    "type": "string"
+                  }
+                },
+                "resources": [
+                  {
+                    "apiVersion": "2018-06-01",
+                    "type": "Microsoft.Compute/virtualMachines",
+                    "name": "[parameters('vmNamemsi')]",
+                    "location": "[parameters('locationmsi')]",
+                    "identity": {
+                      "type": "SystemAssigned"
+                    }
+                  },
+                  {
+                    "apiVersion": "2020-06-01",
+                    "name": "[concat(parameters('vmName'), '/AADSSHLoginForLinux')]",
+                    "type": "Microsoft.Compute/virtualMachines/extensions",
+                    "location": "[parameters('location')]",
+                    "properties": {
+                      "autoUpgradeMinorVersion": true,
+                      "publisher": "Microsoft.Azure.ActiveDirectory",
+                      "type": "AADSSHLoginForLinux",
+                      "typeHandlerVersion": "1.0"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "parameters": {
+      "PublishersToExclude": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Optional: List Of Image Publishers to exclude",
+          "description": "List of Linux image Publishers to exclude from AAD Login for Linux SSH provision"
+        },
+        "defaultValue": []
+      },
+      "ImageIdsToExclude": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Optional: List of virtual machine images to exclude",
+          "description": "Example value: '/subscriptions/<subscriptionId>/resourceGroups/YourResourceGroup/providers/Microsoft.Compute/images/ContosoImage'"
+        },
+        "defaultValue": []
+      },
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "DeployIfNotExists",
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists"
+      }
+    }
+  }

--- a/Policies/Compute/[Preview] Deploy AAD Login For Windows extension on Windows virtual machines/README.md
+++ b/Policies/Compute/[Preview] Deploy AAD Login For Windows extension on Windows virtual machines/README.md
@@ -1,0 +1,18 @@
+# Deploy AAD login for Windows extension on Windows virtual machines
+Author: Nathan Swift
+
+This policy deploys AAD login for Windows extension on Windows virtual machines and sets the VM with MSI. This will join the Server as a device to AAD tenant.
+
+# Contributing
+
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments. 

--- a/Policies/Compute/[Preview] Deploy AAD Login For Windows extension on Windows virtual machines/deploy-aadlogin.json
+++ b/Policies/Compute/[Preview] Deploy AAD Login For Windows extension on Windows virtual machines/deploy-aadlogin.json
@@ -1,0 +1,222 @@
+{
+    "mode": "Indexed",
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Compute/virtualMachines"
+          },
+          {
+            "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
+            "like": "Windows*"
+          },
+          {
+            "anyOf": [
+              {
+                "not": {
+                  "field": "Microsoft.Compute/virtualMachines/imagePublisher",
+                  "in": "[parameters('PublishersToExclude')]"
+                }
+              },
+              {
+                "value": "[empty(parameters('PublishersToExclude'))]",
+                "equals": "true"
+              }
+            ]
+          },
+          {
+            "anyOf": [
+              {
+                "not": {
+                  "field": "Microsoft.Compute/virtualMachines/storageProfile.imageReference.id",
+                  "in": "[parameters('ImageIdsToExclude')]"
+                }
+              },
+              {
+                "value": "[empty(parameters('ImageIdsToExclude'))]",
+                "equals": "true"
+              }
+            ]
+          },
+          {
+            "anyOf": [
+              {
+                "not": {
+                  "anyOf": [
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "contains": "win7"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "contains": "win8"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "MicrosoftWindowsDesktop"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "contains": "2008"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "contains": "2012-R2-Datacenter"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imageSKU",
+                      "contains": "2016-Datacenter"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "azureopenshift"
+                    },
+                    {
+                      "field": "Microsoft.Compute/imagePublisher",
+                      "equals": "AzureDatabricks"
+                    }
+                  ]
+                }
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "equals": "MicrosoftWindowsDesktop"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageSKU",
+                    "contains": "evd"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "roleDefinitionIds": [
+            "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+          ],
+          "type": "Microsoft.Compute/virtualMachines/extensions",
+          "name": "AADLoginForWindows",
+          "existenceCondition": {
+            "allOf": [
+              {
+                "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+                "equals": "Microsoft.Azure.ActiveDirectory"
+              },
+              {
+                "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                "equals": "AADLoginForWindows"
+              },
+              {
+                "field": "Microsoft.Compute/virtualMachines/extensions/provisioningState",
+                "equals": "Succeeded"
+              }
+            ]
+          },
+          "deployment": {
+            "properties": {
+              "mode": "incremental",
+              "parameters": {
+                "vmName": {
+                  "value": "[field('name')]"
+                },
+                "vmNamemsi": {
+                  "value": "[field('name')]"
+                },
+                "location": {
+                  "value": "[field('location')]"
+                },
+                "locationmsi": {
+                  "value": "[field('location')]"
+                },
+                "azureResourceId": {
+                  "value": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/',field('name'))]"
+                }
+              },
+              "template": {
+                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {
+                  "vmName": {
+                    "type": "string"
+                  },
+                  "vmNamemsi": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "locationmsi": {
+                    "type": "string"
+                  },
+                  "azureResourceId": {
+                    "type": "string"
+                  }
+                },
+                "resources": [
+                  {
+                    "apiVersion": "2018-06-01",
+                    "type": "Microsoft.Compute/virtualMachines",
+                    "name": "[parameters('vmNamemsi')]",
+                    "location": "[parameters('locationmsi')]",
+                    "identity": {
+                      "type": "SystemAssigned"
+                    }
+                  },
+                  {
+                    "apiVersion": "2020-06-01",
+                    "name": "[concat(parameters('vmName'), '/AADLoginForWindows')]",
+                    "type": "Microsoft.Compute/virtualMachines/extensions",
+                    "location": "[parameters('location')]",
+                    "properties": {
+                      "autoUpgradeMinorVersion": true,
+                      "publisher": "Microsoft.Azure.ActiveDirectory",
+                      "type": "AADLoginForWindows",
+                      "typeHandlerVersion": "1.0"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "parameters": {
+      "PublishersToExclude": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Optional: List Of Image Publishers to exclude",
+          "description": "List of Windows image Publishers to exclude from AADLoginForWindows provision"
+        },
+        "defaultValue": []
+      },
+      "ImageIdsToExclude": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Optional: List of virtual machine images to exclude",
+          "description": "Example value: '/subscriptions/<subscriptionId>/resourceGroups/YourResourceGroup/providers/Microsoft.Compute/images/ContosoImage'"
+        },
+        "defaultValue": []
+      },
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "DeployIfNotExists",
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists"
+      }
+    }
+  }


### PR DESCRIPTION
This policy deploys AAD login for Linux SSH extension on Linux virtual machines and sets the VM with MSI.

This policy deploys AAD login for Windows extension on Windows virtual machines and sets the VM with MSI. This will join the Server as a device to AAD tenant.