### PR TITLE
Added Enhanced "Configure periodic checking for missing system updates on azure virtual machines" policy

### DIFF
--- a/Policies/Update Management Center/enhanced Configure periodic checking for missing system updates on azure virtual machines/README.md
+++ b/Policies/Update Management Center/enhanced Configure periodic checking for missing system updates on azure virtual machines/README.md
@@ -1,0 +1,32 @@
+# Enhanced Configure periodic checking for missing system updates on azure virtual machines
+
+This custom policy is **enhancing** Microsofts Configure auto-assessment (every 24 hours) for OS updates on native Azure virtual machines. You can control the scope of assignment according to machine subscription, resource group, location or tags. Learn more about this for Windows: https://aka.ms/computevm-windowspatchassessmentmode, for Linux: https://aka.ms/computevm-linuxpatchassessmentmode.
+
+The Microsoft provided built-in policy for Azure Update Management Center lacks of the possibility to define multiple possible tag-values for the same tag-key. This prohibits the strategy to enable periodic checking for missing system updates on VMs that belong to one of the "valid" update schedules.
+
+Many organizations pre-define possible update schedules like "wave1", "wave2" or "Dev", "Test" and "Prod". The current implementation of Microsofts policy does not allow to apply the policy to all VMs belonging to one of those update schedules. That is why I enhanced this policy with the logic from another Microsoft policy ("[Preview]: Schedule recurring updates using Update Management Center") which allows the definition of an array of possible tag-values for the same key which are then combined with a logical OR operator via the tagOperator "Any". This approach also supports the "All" (or logical AND) operator.
+
+In Microsofts policy, you would have to define something like this as a tags parameter (which does not work of course).
+{
+    'UpdateWave': 'Alpha',
+    'UpdateWave': 'Beta',
+    'UpdateWave': 'Production1-AP',
+}
+
+With my modified policy this now becomes possible as you could define the tag filter as follows:
+[
+    {
+        "key": "UpdateWave",
+        "value": "Alpha"
+    },
+    {
+        "key": "UpdateWave",
+        "value": "Beta"
+    },
+    {
+        "key": "UpdateWave",
+        "value": "Production1-EU"
+    }
+]
+
+

--- a/Policies/Update Management Center/enhanced Configure periodic checking for missing system updates on azure virtual machines/azurepolicy.json
+++ b/Policies/Update Management Center/enhanced Configure periodic checking for missing system updates on azure virtual machines/azurepolicy.json
@@ -1,0 +1,455 @@
+{
+    "mode": "Indexed",
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Compute/virtualMachines"
+          },
+          {
+            "anyOf": [
+              {
+                "value": "[empty(parameters('locations'))]",
+                "equals": true
+              },
+              {
+                "field": "location",
+                "in": "[parameters('locations')]"
+              }
+            ]
+          },
+          {
+            "field": "[if(equals(parameters('osType'), 'Windows'), 'Microsoft.Compute/virtualMachines/osProfile.windowsConfiguration.patchSettings.assessmentMode', 'Microsoft.Compute/virtualMachines/osProfile.linuxConfiguration.patchSettings.assessmentMode')]",
+            "notEquals": "[parameters('assessmentMode')]"
+          },
+          {
+              "anyOf": [
+                {
+                  "value": "[empty(parameters('tagValues'))]",
+                  "equals": true
+                },
+                {
+                  "allOf": [
+                    {
+                      "value": "[empty(field('tags'))]",
+                      "equals": false
+                    },
+                    {
+                      "value": "[parameters('tagOperator')]",
+                      "equals": "Any"
+                    },
+                    {
+                      "count": {
+                        "value": "[parameters('tagValues')]",
+                        "name": "tagKvp",
+                        "where": {
+                          "value": "[length(intersection(createObject(current('tagKvp').key, current('tagKvp').value), field('tags')))]",
+                          "greater": 0
+                        }
+                      },
+                      "greater": 0
+                    }
+                  ]
+                },
+                {
+                  "allOf": [
+                    {
+                      "value": "[empty(field('tags'))]",
+                      "equals": false
+                    },
+                    {
+                      "value": "[parameters('tagOperator')]",
+                      "equals": "All"
+                    },
+                    {
+                      "count": {
+                        "value": "[parameters('tagValues')]",
+                        "name": "tagKvp",
+                        "where": {
+                          "value": "[length(intersection(createObject(current('tagKvp').key, current('tagKvp').value), field('tags')))]",
+                          "greater": 0
+                        }
+                      },
+                      "equals": "[length(parameters('tagValues'))]"
+                    }
+                  ]
+                }
+              ]
+          },
+          {
+            "anyOf": [
+              {
+                "allOf": [
+                  {
+                    "value": "[parameters('osType')]",
+                    "equals": "Linux"
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "allOf": [
+                          {
+                            "field": "Microsoft.Compute/imagePublisher",
+                            "equals": "Canonical"
+                          },
+                          {
+                            "anyOf": [
+                              {
+                                "allOf": [
+                                  {
+                                    "field": "Microsoft.Compute/imageOffer",
+                                    "equals": "UbuntuServer"
+                                  },
+                                  {
+                                    "field": "Microsoft.Compute/imageSKU",
+                                    "in": [
+                                      "16.04-LTS",
+                                      "18.04-LTS",
+                                      "18.04-LTS-Gen2"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "allOf": [
+                                  {
+                                    "field": "Microsoft.Compute/imageOffer",
+                                    "equals": "0001-com-ubuntu-pro-bionic"
+                                  },
+                                  {
+                                    "field": "Microsoft.Compute/imageSKU",
+                                    "equals": "pro-18_04-lts"
+                                  }
+                                ]
+                              },
+                              {
+                                "allOf": [
+                                  {
+                                    "field": "Microsoft.Compute/imageOffer",
+                                    "equals": "0001-com-ubuntu-server-focal"
+                                  },
+                                  {
+                                    "field": "Microsoft.Compute/imageSKU",
+                                    "in": [
+                                      "20_04-lts",
+                                      "20_04-lts-gen2"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "allOf": [
+                                  {
+                                    "field": "Microsoft.Compute/imageOffer",
+                                    "equals": "0001-com-ubuntu-pro-focal"
+                                  },
+                                  {
+                                    "field": "Microsoft.Compute/imageSKU",
+                                    "equals": "pro-20_04-lts"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "allOf": [
+                          {
+                            "field": "Microsoft.Compute/imagePublisher",
+                            "equals": "microsoftcblmariner"
+                          },
+                          {
+                            "field": "Microsoft.Compute/imageOffer",
+                            "equals": "cbl-mariner"
+                          },
+                          {
+                            "field": "Microsoft.Compute/imageSKU",
+                            "in": [
+                              "cbl-mariner-1",
+                              "1-gen2",
+                              "cbl-mariner-2",
+                              "cbl-mariner-2-gen2"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "allOf": [
+                          {
+                            "field": "Microsoft.Compute/imagePublisher",
+                            "equals": "microsoft-aks"
+                          },
+                          {
+                            "field": "Microsoft.Compute/imageOffer",
+                            "equals": "aks"
+                          },
+                          {
+                            "field": "Microsoft.Compute/imageSKU",
+                            "equals": "aks-engine-ubuntu-1804-202112"
+                          }
+                        ]
+                      },
+                      {
+                        "allOf": [
+                          {
+                            "field": "Microsoft.Compute/imagePublisher",
+                            "equals": "Redhat"
+                          },
+                          {
+                            "anyOf": [
+                              {
+                                "allOf": [
+                                  {
+                                    "field": "Microsoft.Compute/imageOffer",
+                                    "equals": "RHEL"
+                                  },
+                                  {
+                                    "field": "Microsoft.Compute/imageSKU",
+                                    "in": [
+                                      "7.2",
+                                      "7.3",
+                                      "7.4",
+                                      "7.5",
+                                      "7.6",
+                                      "7.7",
+                                      "7.8",
+                                      "7_9",
+                                      "7-RAW",
+                                      "7-LVM",
+                                      "8",
+                                      "8.1",
+                                      "8.2",
+                                      "8_3",
+                                      "8_4",
+                                      "8_5",
+                                      "8-LVM"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "allOf": [
+                                  {
+                                    "field": "Microsoft.Compute/imageOffer",
+                                    "equals": "RHEL-RAW"
+                                  },
+                                  {
+                                    "field": "Microsoft.Compute/imageSKU",
+                                    "equals": "8-raw"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "allOf": [
+                          {
+                            "field": "Microsoft.Compute/imagePublisher",
+                            "equals": "OpenLogic"
+                          },
+                          {
+                            "anyOf": [
+                              {
+                                "allOf": [
+                                  {
+                                    "field": "Microsoft.Compute/imageOffer",
+                                    "equals": "Centos"
+                                  },
+                                  {
+                                    "field": "Microsoft.Compute/imageSKU",
+                                    "in": [
+                                      "7.2",
+                                      "7.3",
+                                      "7.4",
+                                      "7.5",
+                                      "7.6",
+                                      "7.7",
+                                      "7_8",
+                                      "7_9",
+                                      "7_9-gen2",
+                                      "8.0",
+                                      "8_1",
+                                      "8_2",
+                                      "8_3",
+                                      "8_4",
+                                      "8_5"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "allOf": [
+                                  {
+                                    "field": "Microsoft.Compute/imageOffer",
+                                    "equals": "centos-lvm"
+                                  },
+                                  {
+                                    "field": "Microsoft.Compute/imageSKU",
+                                    "in": [
+                                      "7-lvm",
+                                      "8-lvm"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "allOf": [
+                          {
+                            "field": "Microsoft.Compute/imagePublisher",
+                            "equals": "SUSE"
+                          },
+                          {
+                            "field": "Microsoft.Compute/imageOffer",
+                            "in": [
+                              "sles-12-sp5",
+                              "sles-15-sp2"
+                            ]
+                          },
+                          {
+                            "field": "Microsoft.Compute/imageSKU",
+                            "in": [
+                              "gen1",
+                              "gen2"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "value": "[parameters('osType')]",
+                    "equals": "Windows"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "equals": "MicrosoftWindowsServer"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "equals": "WindowsServer"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageSKU",
+                    "in": [
+                      "2008-R2-SP1",
+                      "2012-R2-Datacenter",
+                      "2016-Datacenter",
+                      "2016-datacenter-gensecond",
+                      "2016-Datacenter-Server-Core",
+                      "2016-datacenter-smalldisk",
+                      "2016-datacenter-with-containers",
+                      "2019-Datacenter",
+                      "2019-Datacenter-Core",
+                      "2019-datacenter-gensecond",
+                      "2019-datacenter-smalldisk",
+                      "2019-datacenter-smalldisk-g2",
+                      "2019-datacenter-with-containers",
+                      "2022-datacenter",
+                      "2022-datacenter-g2",
+                      "2022-datacenter-core",
+                      "2022-datacenter-core-g2",
+                      "2022-datacenter-azure-edition",
+                      "2022-datacenter-azure-edition-core",
+                      "2022-datacenter-azure-edition-core-smalldisk",
+                      "2022-datacenter-azure-edition-smalldisk",
+                      "2022-datacenter-smalldisk-g2"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "modify",
+        "details": {
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+          ],
+          "conflictEffect": "audit",
+          "operations": [
+            {
+              "condition": "[equals(parameters('osType'), 'Windows')]",
+              "operation": "addOrReplace",
+              "field": "Microsoft.Compute/virtualMachines/osProfile.windowsConfiguration.patchSettings.assessmentMode",
+              "value": "[parameters('assessmentMode')]"
+            },
+            {
+              "condition": "[equals(parameters('osType'), 'Linux')]",
+              "operation": "addOrReplace",
+              "field": "Microsoft.Compute/virtualMachines/osProfile.linuxConfiguration.patchSettings.assessmentMode",
+              "value": "[parameters('assessmentMode')]"
+            }
+          ]
+        }
+      }
+    },
+    "parameters": {
+      "assessmentMode": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Assessment mode",
+          "description": "Assessment mode for the machines."
+        },
+        "allowedValues": [
+          "ImageDefault",
+          "AutomaticByPlatform"
+        ],
+        "defaultValue": "AutomaticByPlatform"
+      },
+      "osType": {
+        "type": "String",
+        "metadata": {
+          "displayName": "OS type",
+          "description": "OS type for the machines."
+        },
+        "allowedValues": [
+          "Windows",
+          "Linux"
+        ],
+        "defaultValue": "Windows"
+      },
+      "locations": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Machines locations",
+          "description": "The list of locations from which machines need to be targeted.",
+          "strongType": "location"
+        },
+        "defaultValue": []
+      },
+      "tagValues": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Tags on machines",
+          "description": "The list of tags that need to matched for getting target machines (case sensitive). Example: [ {\"key\": \"tagKey1\", \"value\": \"value1\"}, {\"key\": \"tagKey2\", \"value\": \"value2\"}]."
+        },
+        "defaultValue": []
+      },
+      "tagOperator": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Tag operator",
+          "description": "Matching condition for resource tags"
+        },
+        "allowedValues": [
+          "All",
+          "Any"
+        ],
+        "defaultValue": "Any"
+      }
+    }
+  }

--- a/Policies/Update Management Center/enhanced Configure periodic checking for missing system updates on azure virtual machines/azurepolicy.parameters.json
+++ b/Policies/Update Management Center/enhanced Configure periodic checking for missing system updates on azure virtual machines/azurepolicy.parameters.json
@@ -1,0 +1,55 @@
+{
+    "assessmentMode": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Assessment mode",
+        "description": "Assessment mode for the machines."
+      },
+      "allowedValues": [
+        "ImageDefault",
+        "AutomaticByPlatform"
+      ],
+      "defaultValue": "AutomaticByPlatform"
+    },
+    "osType": {
+      "type": "String",
+      "metadata": {
+        "displayName": "OS type",
+        "description": "OS type for the machines."
+      },
+      "allowedValues": [
+        "Windows",
+        "Linux"
+      ],
+      "defaultValue": "Windows"
+    },
+    "locations": {
+      "type": "Array",
+      "metadata": {
+        "displayName": "Machines locations",
+        "description": "The list of locations from which machines need to be targeted.",
+        "strongType": "location"
+      },
+      "defaultValue": []
+    },
+    "tagValues": {
+      "type": "Array",
+      "metadata": {
+        "displayName": "Tags on machines",
+        "description": "The list of tags that need to matched for getting target machines (case sensitive). Example: [ {\"key\": \"tagKey1\", \"value\": \"value1\"}, {\"key\": \"tagKey2\", \"value\": \"value2\"}]."
+      },
+      "defaultValue": []
+    },
+    "tagOperator": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Tag operator",
+        "description": "Matching condition for resource tags"
+      },
+      "allowedValues": [
+        "All",
+        "Any"
+      ],
+      "defaultValue": "Any"
+    }
+  }

--- a/Policies/Update Management Center/enhanced Configure periodic checking for missing system updates on azure virtual machines/azurepolicy.rules.json
+++ b/Policies/Update Management Center/enhanced Configure periodic checking for missing system updates on azure virtual machines/azurepolicy.rules.json
@@ -1,0 +1,397 @@
+{
+    "if": {
+      "allOf": [
+        {
+          "field": "type",
+          "equals": "Microsoft.Compute/virtualMachines"
+        },
+        {
+          "anyOf": [
+            {
+              "value": "[empty(parameters('locations'))]",
+              "equals": true
+            },
+            {
+              "field": "location",
+              "in": "[parameters('locations')]"
+            }
+          ]
+        },
+        {
+          "field": "[if(equals(parameters('osType'), 'Windows'), 'Microsoft.Compute/virtualMachines/osProfile.windowsConfiguration.patchSettings.assessmentMode', 'Microsoft.Compute/virtualMachines/osProfile.linuxConfiguration.patchSettings.assessmentMode')]",
+          "notEquals": "[parameters('assessmentMode')]"
+        },
+        {
+            "anyOf": [
+              {
+                "value": "[empty(parameters('tagValues'))]",
+                "equals": true
+              },
+              {
+                "allOf": [
+                  {
+                    "value": "[empty(field('tags'))]",
+                    "equals": false
+                  },
+                  {
+                    "value": "[parameters('tagOperator')]",
+                    "equals": "Any"
+                  },
+                  {
+                    "count": {
+                      "value": "[parameters('tagValues')]",
+                      "name": "tagKvp",
+                      "where": {
+                        "value": "[length(intersection(createObject(current('tagKvp').key, current('tagKvp').value), field('tags')))]",
+                        "greater": 0
+                      }
+                    },
+                    "greater": 0
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "value": "[empty(field('tags'))]",
+                    "equals": false
+                  },
+                  {
+                    "value": "[parameters('tagOperator')]",
+                    "equals": "All"
+                  },
+                  {
+                    "count": {
+                      "value": "[parameters('tagValues')]",
+                      "name": "tagKvp",
+                      "where": {
+                        "value": "[length(intersection(createObject(current('tagKvp').key, current('tagKvp').value), field('tags')))]",
+                        "greater": 0
+                      }
+                    },
+                    "equals": "[length(parameters('tagValues'))]"
+                  }
+                ]
+              }
+            ]
+        },
+        {
+          "anyOf": [
+            {
+              "allOf": [
+                {
+                  "value": "[parameters('osType')]",
+                  "equals": "Linux"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "allOf": [
+                        {
+                          "field": "Microsoft.Compute/imagePublisher",
+                          "equals": "Canonical"
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "allOf": [
+                                {
+                                  "field": "Microsoft.Compute/imageOffer",
+                                  "equals": "UbuntuServer"
+                                },
+                                {
+                                  "field": "Microsoft.Compute/imageSKU",
+                                  "in": [
+                                    "16.04-LTS",
+                                    "18.04-LTS",
+                                    "18.04-LTS-Gen2"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "allOf": [
+                                {
+                                  "field": "Microsoft.Compute/imageOffer",
+                                  "equals": "0001-com-ubuntu-pro-bionic"
+                                },
+                                {
+                                  "field": "Microsoft.Compute/imageSKU",
+                                  "equals": "pro-18_04-lts"
+                                }
+                              ]
+                            },
+                            {
+                              "allOf": [
+                                {
+                                  "field": "Microsoft.Compute/imageOffer",
+                                  "equals": "0001-com-ubuntu-server-focal"
+                                },
+                                {
+                                  "field": "Microsoft.Compute/imageSKU",
+                                  "in": [
+                                    "20_04-lts",
+                                    "20_04-lts-gen2"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "allOf": [
+                                {
+                                  "field": "Microsoft.Compute/imageOffer",
+                                  "equals": "0001-com-ubuntu-pro-focal"
+                                },
+                                {
+                                  "field": "Microsoft.Compute/imageSKU",
+                                  "equals": "pro-20_04-lts"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "field": "Microsoft.Compute/imagePublisher",
+                          "equals": "microsoftcblmariner"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageOffer",
+                          "equals": "cbl-mariner"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "in": [
+                            "cbl-mariner-1",
+                            "1-gen2",
+                            "cbl-mariner-2",
+                            "cbl-mariner-2-gen2"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "field": "Microsoft.Compute/imagePublisher",
+                          "equals": "microsoft-aks"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageOffer",
+                          "equals": "aks"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "equals": "aks-engine-ubuntu-1804-202112"
+                        }
+                      ]
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "field": "Microsoft.Compute/imagePublisher",
+                          "equals": "Redhat"
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "allOf": [
+                                {
+                                  "field": "Microsoft.Compute/imageOffer",
+                                  "equals": "RHEL"
+                                },
+                                {
+                                  "field": "Microsoft.Compute/imageSKU",
+                                  "in": [
+                                    "7.2",
+                                    "7.3",
+                                    "7.4",
+                                    "7.5",
+                                    "7.6",
+                                    "7.7",
+                                    "7.8",
+                                    "7_9",
+                                    "7-RAW",
+                                    "7-LVM",
+                                    "8",
+                                    "8.1",
+                                    "8.2",
+                                    "8_3",
+                                    "8_4",
+                                    "8_5",
+                                    "8-LVM"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "allOf": [
+                                {
+                                  "field": "Microsoft.Compute/imageOffer",
+                                  "equals": "RHEL-RAW"
+                                },
+                                {
+                                  "field": "Microsoft.Compute/imageSKU",
+                                  "equals": "8-raw"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "field": "Microsoft.Compute/imagePublisher",
+                          "equals": "OpenLogic"
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "allOf": [
+                                {
+                                  "field": "Microsoft.Compute/imageOffer",
+                                  "equals": "Centos"
+                                },
+                                {
+                                  "field": "Microsoft.Compute/imageSKU",
+                                  "in": [
+                                    "7.2",
+                                    "7.3",
+                                    "7.4",
+                                    "7.5",
+                                    "7.6",
+                                    "7.7",
+                                    "7_8",
+                                    "7_9",
+                                    "7_9-gen2",
+                                    "8.0",
+                                    "8_1",
+                                    "8_2",
+                                    "8_3",
+                                    "8_4",
+                                    "8_5"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "allOf": [
+                                {
+                                  "field": "Microsoft.Compute/imageOffer",
+                                  "equals": "centos-lvm"
+                                },
+                                {
+                                  "field": "Microsoft.Compute/imageSKU",
+                                  "in": [
+                                    "7-lvm",
+                                    "8-lvm"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "field": "Microsoft.Compute/imagePublisher",
+                          "equals": "SUSE"
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageOffer",
+                          "in": [
+                            "sles-12-sp5",
+                            "sles-15-sp2"
+                          ]
+                        },
+                        {
+                          "field": "Microsoft.Compute/imageSKU",
+                          "in": [
+                            "gen1",
+                            "gen2"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "allOf": [
+                {
+                  "value": "[parameters('osType')]",
+                  "equals": "Windows"
+                },
+                {
+                  "field": "Microsoft.Compute/imagePublisher",
+                  "equals": "MicrosoftWindowsServer"
+                },
+                {
+                  "field": "Microsoft.Compute/imageOffer",
+                  "equals": "WindowsServer"
+                },
+                {
+                  "field": "Microsoft.Compute/imageSKU",
+                  "in": [
+                    "2008-R2-SP1",
+                    "2012-R2-Datacenter",
+                    "2016-Datacenter",
+                    "2016-datacenter-gensecond",
+                    "2016-Datacenter-Server-Core",
+                    "2016-datacenter-smalldisk",
+                    "2016-datacenter-with-containers",
+                    "2019-Datacenter",
+                    "2019-Datacenter-Core",
+                    "2019-datacenter-gensecond",
+                    "2019-datacenter-smalldisk",
+                    "2019-datacenter-smalldisk-g2",
+                    "2019-datacenter-with-containers",
+                    "2022-datacenter",
+                    "2022-datacenter-g2",
+                    "2022-datacenter-core",
+                    "2022-datacenter-core-g2",
+                    "2022-datacenter-azure-edition",
+                    "2022-datacenter-azure-edition-core",
+                    "2022-datacenter-azure-edition-core-smalldisk",
+                    "2022-datacenter-azure-edition-smalldisk",
+                    "2022-datacenter-smalldisk-g2"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "then": {
+      "effect": "modify",
+      "details": {
+        "roleDefinitionIds": [
+          "/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+        ],
+        "conflictEffect": "audit",
+        "operations": [
+          {
+            "condition": "[equals(parameters('osType'), 'Windows')]",
+            "operation": "addOrReplace",
+            "field": "Microsoft.Compute/virtualMachines/osProfile.windowsConfiguration.patchSettings.assessmentMode",
+            "value": "[parameters('assessmentMode')]"
+          },
+          {
+            "condition": "[equals(parameters('osType'), 'Linux')]",
+            "operation": "addOrReplace",
+            "field": "Microsoft.Compute/virtualMachines/osProfile.linuxConfiguration.patchSettings.assessmentMode",
+            "value": "[parameters('assessmentMode')]"
+          }
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
# Enhanced Configure periodic checking for missing system updates on azure virtual machines

This custom policy is **enhancing** Microsofts Configure auto-assessment (every 24 hours) for OS updates on native Azure virtual machines. You can control the scope of assignment according to machine subscription, resource group, location or tags. Learn more about this for Windows: https://aka.ms/computevm-windowspatchassessmentmode, for Linux: https://aka.ms/computevm-linuxpatchassessmentmode.

The Microsoft provided built-in policy for Azure Update Management Center lacks of the possibility to define multiple possible tag-values for the same tag-key. This prohibits the strategy to enable periodic checking for missing system updates on VMs that belong to one of the "valid" update schedules.

Many organizations pre-define possible update schedules like "wave1", "wave2" or "Dev", "Test" and "Prod". The current implementation of Microsofts policy does not allow to apply the policy to all VMs belonging to one of those update schedules. That is why I enhanced this policy with the logic from another Microsoft policy ("[Preview]: Schedule recurring updates using Update Management Center") which allows the definition of an array of possible tag-values for the same key which are then combined with a logical OR operator via the tagOperator "Any". This approach also supports the "All" (or logical AND) operator.

In Microsofts policy, you would have to define something like this as a tags parameter (which does not work of course).
{
    'UpdateWave': 'Alpha',
    'UpdateWave': 'Beta',
    'UpdateWave': 'Production1-AP',
}

With my modified policy this now becomes possible as you could define the tag filter as follows:
[
    {
        "key": "UpdateWave",
        "value": "Alpha"
    },
    {
        "key": "UpdateWave",
        "value": "Beta"
    },
    {
        "key": "UpdateWave",
        "value": "Production1-EU"
    }
]


