### PR TITLE
Bugfix enforce_vnet_dns_servers edge-case of empty array

### DIFF
--- a/Policies/Network/enforce_vnet_dns_servers/azurepolicy.json
+++ b/Policies/Network/enforce_vnet_dns_servers/azurepolicy.json
@@ -42,7 +42,7 @@
           "anyOf": [
             {
               "exists": false,
-              "field": "Microsoft.Network/virtualNetworks/dhcpOptions.dnsServers"
+              "field": "Microsoft.Network/virtualNetworks/dhcpOptions.dnsServers[*]"
             },
             {
               "count": {


### PR DESCRIPTION
a bugfix to address an edge-case that was discovered - supplying an empty array in the arm/bicep template for dns servers caused the first "anyOf" check to pass, despite it being empty, so the policy failed to apply as intended.  

The fix forces the test to be against an array that has something (anything!) in it, so that the test then moves on to the second part to test against the allowed list.