### PR TITLE
Adding Azure Policy for denying/auditing authorizations keys for ExpressRoute.

### DIFF
--- a/Policies/Network/deny-expressroute-authorization-key/azurepolicy.json
+++ b/Policies/Network/deny-expressroute-authorization-key/azurepolicy.json
@@ -16,7 +16,8 @@
             },
             "allowedValues": [
                 "Deny",
-                "Audit"
+                "Audit",
+                "Disabled"
             ],
             "defaultValue": "Deny"
         }

--- a/Policies/Network/deny-expressroute-authorization-key/azurepolicy.json
+++ b/Policies/Network/deny-expressroute-authorization-key/azurepolicy.json
@@ -1,0 +1,43 @@
+{
+    "displayName": "ExpressRoute should not use Authorization keys",
+    "policyType": "Custom",
+    "mode": "Indexed",
+    "description": "This policy denies the creation of Authorization keys for the ExpressRoute. Authorization keys are used to enable cross-subscription/cross-tenant networking functionality to the ExpressRoute. This should be reviewed by the network security team. https://learn.microsoft.com/en-us/azure/expressroute/expressroute-howto-linkvnet-portal-resource-manager",
+    "metadata": {
+        "version": "1.0.0",
+        "category": "Network"
+    },
+    "parameters": {
+        "effect": {
+            "type": "String",
+            "metadata": {
+                "displayName": "Effect",
+                "description": "Deny or Audit the use of authorization key for ExpressRoute"
+            },
+            "allowedValues": [
+                "Deny",
+                "Audit"
+            ],
+            "defaultValue": "Deny"
+        }
+    },
+    "policyRule": {
+        "if": {
+            "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.Network/expressRouteCircuits"
+                },
+                {
+                    "count": {
+                        "field": "Microsoft.Network/expressRouteCircuits/authorizations[*]"
+                    },
+                    "greaterOrEquals": 1
+                }
+            ]
+        },
+        "then": {
+            "effect": "[parameters('effect')]"
+        }
+    }
+}

--- a/Policies/Network/deny-expressroute-authorization-key/azurepolicy.parameters.json
+++ b/Policies/Network/deny-expressroute-authorization-key/azurepolicy.parameters.json
@@ -7,7 +7,8 @@
         },
         "allowedValues": [
             "Deny",
-            "Audit"
+            "Audit",
+            "Disabled"
         ],
         "defaultValue": "Deny"
     }

--- a/Policies/Network/deny-expressroute-authorization-key/azurepolicy.parameters.json
+++ b/Policies/Network/deny-expressroute-authorization-key/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+    "effect": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Effect",
+            "description": "Deny or Audit the use of authorization key for ExpressRoute"
+        },
+        "allowedValues": [
+            "Deny",
+            "Audit"
+        ],
+        "defaultValue": "Deny"
+    }
+}

--- a/Policies/Network/deny-expressroute-authorization-key/azurepolicy.rules.json
+++ b/Policies/Network/deny-expressroute-authorization-key/azurepolicy.rules.json
@@ -1,0 +1,19 @@
+{
+    "if": {
+        "allOf": [
+            {
+                "field": "type",
+                "equals": "Microsoft.Network/expressRouteCircuits"
+            },
+            {
+                "count": {
+                    "field": "Microsoft.Network/expressRouteCircuits/authorizations[*]"
+                },
+                "greaterOrEquals": 1
+            }
+        ]
+    },
+    "then": {
+        "effect": "[parameters('effect')]"
+    }
+}


### PR DESCRIPTION
Adding Azure policy to audit/deny the creation of authorization keys for ExpressRoute.

Authorization keys for ExpressRoute is used to enable cross-subscription/tenant network connectivity.
The process for generating these keys should be through a process owned by the network team.