### PR TITLE
Add: Azure policies to block the use of DNAT rules / rule collection type.

### DIFF
--- a/Policies/Compute/VM use allowed Images/azurepolicy.json
+++ b/Policies/Compute/VM use allowed Images/azurepolicy.json
@@ -2,7 +2,7 @@
   "Description": "This policy prevents unauthorized images for VMs.",
   "DisplayName": "VM use allowed Images",
   "Metadata": {
-    "category": "Virtual Machines",
+    "category": "Compute",
     "createdBy": "",
     "createdOn": "2021-10-05T10:08:32.2863292Z",
     "updatedBy": null,

--- a/Policies/Compute/[Preview] Deploy AAD Login For Linux SSH extension on Linux virtual machines/deploy-aadlogin.json
+++ b/Policies/Compute/[Preview] Deploy AAD Login For Linux SSH extension on Linux virtual machines/deploy-aadlogin.json
@@ -1,5 +1,8 @@
 {
     "mode": "Indexed",
+    "Metadata": {
+      "category": "Compute"
+    },
     "policyRule": {
       "if": {
         "allOf": [

--- a/Policies/Compute/[Preview] Deploy AAD Login For Windows extension on Windows virtual machines/deploy-aadlogin.json
+++ b/Policies/Compute/[Preview] Deploy AAD Login For Windows extension on Windows virtual machines/deploy-aadlogin.json
@@ -1,5 +1,8 @@
 {
     "mode": "Indexed",
+    "Metadata": {
+      "category": "Compute"
+    },
     "policyRule": {
       "if": {
         "allOf": [

--- a/Policies/Compute/allowed-disk-skus/azurepolicy.json
+++ b/Policies/Compute/allowed-disk-skus/azurepolicy.json
@@ -1,5 +1,8 @@
 {
     "mode": "All",
+    "Metadata": {
+        "category": "Compute"
+    },
     "parameters": {
         "allowedDiskSkus": {
             "type": "Array",

--- a/Policies/Compute/allowed-vm-os/azurepolicy.json
+++ b/Policies/Compute/allowed-vm-os/azurepolicy.json
@@ -1,5 +1,8 @@
 {
     "mode": "All",
+    "Metadata": {
+        "category": "Compute"
+    },
     "policyRule": {
         "if": {
             "allOf": [

--- a/Policies/Compute/audit-existing-linux-vm-ssh-with-password/azurepolicy.json
+++ b/Policies/Compute/audit-existing-linux-vm-ssh-with-password/azurepolicy.json
@@ -1,6 +1,9 @@
 {
     "type": "Microsoft.Authorization/policyDefinitions",
-    "name": "audit-existing-linux-vm-ssh-with-password", 
+    "name": "audit-existing-linux-vm-ssh-with-password",
+    "Metadata": {
+        "category": "Compute"
+    },
     "properties": {
         "mode": "all",
         "displayName": "Audit SSH Auth on Existing Resources",

--- a/Policies/Compute/blocked-disk-skus/azurepolicy.json
+++ b/Policies/Compute/blocked-disk-skus/azurepolicy.json
@@ -1,5 +1,8 @@
 {
     "mode": "All",
+    "Metadata": {
+        "category": "Compute"
+    },
     "parameters": {
         "blockedDiskSkus": {
             "type": "Array",

--- a/Policies/Compute/deny-new-linux-vm-ssh-with-password/azurepolicy.json
+++ b/Policies/Compute/deny-new-linux-vm-ssh-with-password/azurepolicy.json
@@ -2,6 +2,9 @@
 	"mode": "all",
 	"displayName": "Deny SSH Auth on New VMs",
 	"description": "This policy denies a deployment when any Linux VMs use password-only authentication for SSH.",
+	"Metadata": {
+        "category": "Compute"
+    },
 	"policyRule": {
 		"if": {
 			"allOf": [

--- a/Policies/Compute/deploy-or-audit-auto-shutdown-by-tag-value-on-vm/azurepolicy.json
+++ b/Policies/Compute/deploy-or-audit-auto-shutdown-by-tag-value-on-vm/azurepolicy.json
@@ -3,7 +3,7 @@
   "policyType": "Custom",
   "mode": "All",
   "metadata": {
-    "category": "Compute",
+    "category": "Compute"
   },
   "parameters": {
     "effect": {

--- a/Policies/Compute/only_approved_vmss_extensions_should_be_installed/azurepolicy.json
+++ b/Policies/Compute/only_approved_vmss_extensions_should_be_installed/azurepolicy.json
@@ -2,7 +2,7 @@
   "Description": "This policy governs the virtual machine scale set extensions that are not approved.",
   "DisplayName": "Only approved VMSS extensions should be installed",
   "Metadata": {
-    "category": "Azure DNS",
+    "category": "Compute",
     "createdBy": "",
     "createdOn": "2021-10-05T13:57:47.7031687Z",
     "updatedBy": null,

--- a/Policies/Compute/vm-extension-vmaccess/azurepolicy.json
+++ b/Policies/Compute/vm-extension-vmaccess/azurepolicy.json
@@ -1,0 +1,40 @@
+{
+    "displayName": "VMAccess virtual machine extension for Linux.",
+    "description": "The VMAccess virtual machine extensions for Linux allows the user to reset the password/ssh of a selected user or the ability to create a new local users with sudo access. https://github.com/Azure/azure-linux-extensions/blob/master/VMAccess/README.md",
+    "mode": "All",
+    "Metadata": {
+        "category": "Compute"
+    },
+    "Parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "description": "Enable or disable the execution of the policy",
+            "displayName": "Effect"
+          },
+          "allowedValues": [
+            "Audit",
+            "Deny",
+            "Disabled"
+          ],
+          "defaultValue": "Deny"
+        }
+      },
+    "policyRule": {
+        "if": {
+            "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.Compute/virtualMachines/extensions"
+                },
+                {
+                    "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                    "equals": "VMAccessForLinux"
+                }
+            ]
+        },
+        "then": {
+            "effect": "[parameters('effect')]"
+          }
+    }
+}

--- a/Policies/Compute/vm-extension-vmaccess/azurepolicy.parameters.json
+++ b/Policies/Compute/vm-extension-vmaccess/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "description": "Enable or disable the execution of the policy",
+        "displayName": "Effect"
+      },
+      "allowedValues": [
+        "Audit",
+        "Deny",
+        "Disabled"
+      ],
+      "defaultValue": "Deny"
+    }
+  }

--- a/Policies/Compute/vm-extension-vmaccess/azurepolicy.rules.json
+++ b/Policies/Compute/vm-extension-vmaccess/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+    "if": {
+        "allOf": [
+            {
+                "field": "type",
+                "equals": "Microsoft.Compute/virtualMachines/extensions"
+            },
+            {
+                "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                "equals": "VMAccessForLinux"
+            }
+        ]
+    },
+    "then": {
+        "effect": "[parameters('effect')]"
+      }
+}

--- a/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.json
@@ -1,6 +1,7 @@
 {
   "displayName": "Azure firewall policy - NAT rule",
   "policyType": "Custom",
+  "description": "NAT rules allows the Azure Firewall to act as an ingress. This should be reviewed and managed by the network security team.",
   "mode": "All",
   "parameters": {
       "effect": {

--- a/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.json
@@ -1,0 +1,43 @@
+{
+  "displayName": "Azure firewall policy - NAT rule",
+  "policyType": "Custom",
+  "mode": "All",
+  "parameters": {
+      "effect": {
+          "type": "String",
+          "metadata": {
+              "displayName": "Effect",
+              "description": "Effect for the use of NAT rule in Azure Firewall Policy"
+          },
+          "allowedValues": [
+              "Deny",
+              "Audit",
+              "Disabled"
+          ],
+          "defaultValue": "Deny"
+      }
+  },
+  "policyRule": {
+      "if": {
+          "allOf": [
+              {
+                  "field": "type",
+                  "equals": "Microsoft.Network/firewallPolicies/ruleCollectionGroups"
+              },
+              {
+                  "count": {
+                      "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*]",
+                      "where": {
+                          "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*].FirewallPolicyFilterRuleCollection.rules[*].ruleType",
+                          "equals": "NatRule"
+                      }
+                  },
+                  "greater": 0
+              }
+          ]
+      },
+      "then": {
+          "effect": "[parameters('effect')]"
+      }
+  }
+}

--- a/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.json
@@ -28,7 +28,7 @@
                   "count": {
                       "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*]",
                       "where": {
-                          "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*].FirewallPolicyFilterRuleCollection.rules[*].ruleType",
+                          "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*].FirewallPolicyNatRuleCollection.rules[*].ruleType",
                           "equals": "NatRule"
                       }
                   },

--- a/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.parameters.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+    "effect": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Effect",
+            "description": "Effect for the use of NAT rule in Azure Firewall Policy"
+        },
+        "allowedValues": [
+            "Deny",
+            "Audit",
+            "Disabled"
+        ],
+        "defaultValue": "Deny"
+    }
+}

--- a/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.rules.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.rules.json
@@ -1,0 +1,23 @@
+{
+  "if": {
+      "allOf": [
+          {
+              "field": "type",
+              "equals": "Microsoft.Network/firewallPolicies/ruleCollectionGroups"
+          },
+          {
+              "count": {
+                  "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*]",
+                  "where": {
+                      "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*].FirewallPolicyFilterRuleCollection.rules[*].ruleType",
+                      "equals": "NatRule"
+                  }
+              },
+              "greater": 0
+          }
+      ]
+  },
+  "then": {
+      "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.rules.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.rules.json
@@ -9,7 +9,7 @@
               "count": {
                   "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*]",
                   "where": {
-                      "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*].FirewallPolicyFilterRuleCollection.rules[*].ruleType",
+                      "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*].FirewallPolicyNatRuleCollection.rules[*].ruleType",
                       "equals": "NatRule"
                   }
               },

--- a/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.json
@@ -1,0 +1,43 @@
+{
+    "displayName": "Azure firewall policy - NAT rule",
+    "policyType": "Custom",
+    "mode": "All",
+    "parameters": {
+        "effect": {
+            "type": "String",
+            "metadata": {
+                "displayName": "Effect",
+                "description": "Effect for the use of NAT rule collection in Azure Firewall Policy"
+            },
+            "allowedValues": [
+                "Deny",
+                "Audit",
+                "Disabled"
+            ],
+            "defaultValue": "Deny"
+        }
+    },
+    "policyRule": {
+        "if": {
+            "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.Network/firewallPolicies/ruleCollectionGroups"
+                },
+                {
+                    "count": {
+                        "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*]",
+                        "where": {
+                            "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*].ruleCollectionType",
+                            "equals": "FirewallPolicyNatRuleCollection"
+                        }
+                    },
+                    "greater": 0
+                }
+            ]
+        },
+        "then": {
+            "effect": "[parameters('effect')]"
+        }
+    }
+}

--- a/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.json
@@ -1,6 +1,7 @@
 {
     "displayName": "Azure firewall policy - Rule collection group of NAT type",
     "policyType": "Custom",
+    "description": "Rule collections of the type NAT allows the Azure Firewall to act as an ingress. This should be reviewed and managed by the network security team.",
     "mode": "All",
     "parameters": {
         "effect": {

--- a/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.json
@@ -1,5 +1,5 @@
 {
-    "displayName": "Azure firewall policy - NAT rule",
+    "displayName": "Azure firewall policy - Rule collection group of NAT type",
     "policyType": "Custom",
     "mode": "All",
     "parameters": {

--- a/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.parameters.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+    "effect": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Effect",
+            "description": "Effect for the use of NAT rule collection in Azure Firewall Policy"
+        },
+        "allowedValues": [
+            "Deny",
+            "Audit",
+            "Disabled"
+        ],
+        "defaultValue": "Deny"
+    }
+}

--- a/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.rules.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.rules.json
@@ -1,0 +1,23 @@
+{
+    "if": {
+        "allOf": [
+            {
+                "field": "type",
+                "equals": "Microsoft.Network/firewallPolicies/ruleCollectionGroups"
+            },
+            {
+                "count": {
+                    "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*]",
+                    "where": {
+                        "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*].ruleCollectionType",
+                        "equals": "FirewallPolicyNatRuleCollection"
+                    }
+                },
+                "greater": 0
+            }
+        ]
+    },
+    "then": {
+        "effect": "[parameters('effect')]"
+    }
+}


### PR DESCRIPTION
Adding Azure policies for auditing/denying Azure Firewall Policy configuration for DNAT rules/rule collection type.

**The reasoning for these policies:**
The usage of Azure firewall to be an ingress in Azure should be a controlled process by the network team and nothing that should be allowed without following the correct process provided by the organizations network team.
The very least, this should be audited/monitored.