### PR TITLE
Adding Azure Firewall NAT Azure Policies

### DIFF
--- a/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.json
@@ -1,0 +1,44 @@
+{
+  "displayName": "Azure firewall policy - NAT rule",
+  "policyType": "Custom",
+  "description": "NAT rules allows the Azure Firewall to act as an ingress. This should be reviewed and managed by the network security team.",
+  "mode": "All",
+  "parameters": {
+      "effect": {
+          "type": "String",
+          "metadata": {
+              "displayName": "Effect",
+              "description": "Effect for the use of NAT rule in Azure Firewall Policy"
+          },
+          "allowedValues": [
+              "Deny",
+              "Audit",
+              "Disabled"
+          ],
+          "defaultValue": "Deny"
+      }
+  },
+  "policyRule": {
+      "if": {
+          "allOf": [
+              {
+                  "field": "type",
+                  "equals": "Microsoft.Network/firewallPolicies/ruleCollectionGroups"
+              },
+              {
+                  "count": {
+                      "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*]",
+                      "where": {
+                          "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*].FirewallPolicyNatRuleCollection.rules[*].ruleType",
+                          "equals": "NatRule"
+                      }
+                  },
+                  "greater": 0
+              }
+          ]
+      },
+      "then": {
+          "effect": "[parameters('effect')]"
+      }
+  }
+}

--- a/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.parameters.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+    "effect": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Effect",
+            "description": "Effect for the use of NAT rule in Azure Firewall Policy"
+        },
+        "allowedValues": [
+            "Deny",
+            "Audit",
+            "Disabled"
+        ],
+        "defaultValue": "Deny"
+    }
+}

--- a/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.rules.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rule-nat-type/azurepolicy.rules.json
@@ -1,0 +1,23 @@
+{
+  "if": {
+      "allOf": [
+          {
+              "field": "type",
+              "equals": "Microsoft.Network/firewallPolicies/ruleCollectionGroups"
+          },
+          {
+              "count": {
+                  "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*]",
+                  "where": {
+                      "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*].FirewallPolicyNatRuleCollection.rules[*].ruleType",
+                      "equals": "NatRule"
+                  }
+              },
+              "greater": 0
+          }
+      ]
+  },
+  "then": {
+      "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.json
@@ -1,0 +1,44 @@
+{
+    "displayName": "Azure firewall policy - Rule collection group of NAT type",
+    "policyType": "Custom",
+    "description": "Rule collections of the type NAT allows the Azure Firewall to act as an ingress. This should be reviewed and managed by the network security team.",
+    "mode": "All",
+    "parameters": {
+        "effect": {
+            "type": "String",
+            "metadata": {
+                "displayName": "Effect",
+                "description": "Effect for the use of NAT rule collection in Azure Firewall Policy"
+            },
+            "allowedValues": [
+                "Deny",
+                "Audit",
+                "Disabled"
+            ],
+            "defaultValue": "Deny"
+        }
+    },
+    "policyRule": {
+        "if": {
+            "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.Network/firewallPolicies/ruleCollectionGroups"
+                },
+                {
+                    "count": {
+                        "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*]",
+                        "where": {
+                            "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*].ruleCollectionType",
+                            "equals": "FirewallPolicyNatRuleCollection"
+                        }
+                    },
+                    "greater": 0
+                }
+            ]
+        },
+        "then": {
+            "effect": "[parameters('effect')]"
+        }
+    }
+}

--- a/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.parameters.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+    "effect": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Effect",
+            "description": "Effect for the use of NAT rule collection in Azure Firewall Policy"
+        },
+        "allowedValues": [
+            "Deny",
+            "Audit",
+            "Disabled"
+        ],
+        "defaultValue": "Deny"
+    }
+}

--- a/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.rules.json
+++ b/Policies/Network/deny-azurefirewallpolicy-rulecollectiongroup-nat-type/azurepolicy.rules.json
@@ -1,0 +1,23 @@
+{
+    "if": {
+        "allOf": [
+            {
+                "field": "type",
+                "equals": "Microsoft.Network/firewallPolicies/ruleCollectionGroups"
+            },
+            {
+                "count": {
+                    "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*]",
+                    "where": {
+                        "field": "Microsoft.Network/firewallPolicies/ruleCollectionGroups/ruleCollections[*].ruleCollectionType",
+                        "equals": "FirewallPolicyNatRuleCollection"
+                    }
+                },
+                "greater": 0
+            }
+        ]
+    },
+    "then": {
+        "effect": "[parameters('effect')]"
+    }
+}


### PR DESCRIPTION
Adding Azure Policy to audit/deny NAT rule / rule collection for Azure Firewall Policy.

The NAT rule allows the Azure firewall to act as an Ingress in Azure.
Ingress through Azure should be monitored and managed by the organizations network team and follow the correct procedure to allow inbound traffic through NAT rules.