### PR TITLE
Adding Azure Policy for VMAccessForLinux vm extension.

### DIFF
--- a/Policies/Compute/vm-extension-vmaccess/README.md
+++ b/Policies/Compute/vm-extension-vmaccess/README.md
@@ -1,3 +1,10 @@
+# Description and purpose of the Azure policy
+This Azure policy blocks/audits the usage of the VM Extension called "VMAccessForLinux".
+VMAccessForLinux allows the user of the VM to reset the ssh key/password for an existing user or create a new user with a password/ssh key with sudo rights.
+
+The process of reseting the password for users or generating a new user should be monitored and follow a defined process to avoid accidental/intentional elevation of rights in the operating system.
+# Deploy the Azure Policy
+## Deploy new Azure policy definition using PowerShell
 ```pwsh
 Login-AzAccount -Tenant "<TenantId>"
 
@@ -6,7 +13,7 @@ $Policy = New-AzPolicyDefinition -Policy ".\Policies\Compute\vm-extension-vmacce
 # Creates a policy assignment on default scope & DoNotEnforce as Enforcement mode.
 New-AzPolicyAssignment -Name "vmaccess-extension-linux" -PolicyDefinition $Policy -EnforcementMode 'DoNotEnforce'
 ```
-# Deploy new Azure policy definition using Az cli
+## Deploy new Azure policy definition using Az cli
 ```pwsh
 
 az policy definition create --name "97d4dc8b-b0bd-42da-aa83-bbf98c0c7ef7" --display-name "VMAccess virtual machine extension for Linux" --rules ".\Policies\Compute\vm-extension-vmaccess\azurepolicy.rules.json" --params ".\Policies\Compute\vm-extension-vmaccess\azurepolicy.parameters.json"
@@ -14,5 +21,5 @@ az policy definition create --name "97d4dc8b-b0bd-42da-aa83-bbf98c0c7ef7" --disp
 az policy assignment create --name "vmaccess-extension-linux" --policy "97d4dc8b-b0bd-42da-aa83-bbf98c0c7ef7" --enforcement-mode 'DoNotEnforce'
 ```
 
-# Deploy using portal.
+## Deploy using portal.
 [Create Policy Definition Blade](https://portal.azure.com/#view/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade)

--- a/Policies/Compute/vm-extension-vmaccess/README.md
+++ b/Policies/Compute/vm-extension-vmaccess/README.md
@@ -1,0 +1,18 @@
+```pwsh
+Login-AzAccount -Tenant "<TenantId>"
+
+$Policy = New-AzPolicyDefinition -Policy ".\Policies\Compute\vm-extension-vmaccess\azurepolicy.json" -Name "97d4dc8b-b0bd-42da-aa83-bbf98c0c7ef7"
+
+# Creates a policy assignment on default scope & DoNotEnforce as Enforcement mode.
+New-AzPolicyAssignment -Name "vmaccess-extension-linux" -PolicyDefinition $Policy -EnforcementMode 'DoNotEnforce'
+```
+# Deploy new Azure policy definition using Az cli
+```pwsh
+
+az policy definition create --name "97d4dc8b-b0bd-42da-aa83-bbf98c0c7ef7" --display-name "VMAccess virtual machine extension for Linux" --rules ".\Policies\Compute\vm-extension-vmaccess\azurepolicy.rules.json" --params ".\Policies\Compute\vm-extension-vmaccess\azurepolicy.parameters.json"
+
+az policy assignment create --name "vmaccess-extension-linux" --policy "97d4dc8b-b0bd-42da-aa83-bbf98c0c7ef7" --enforcement-mode 'DoNotEnforce'
+```
+
+# Deploy using portal.
+[Create Policy Definition Blade](https://portal.azure.com/#view/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade)

--- a/Policies/Compute/vm-extension-vmaccess/azurepolicy.json
+++ b/Policies/Compute/vm-extension-vmaccess/azurepolicy.json
@@ -1,0 +1,40 @@
+{
+    "displayName": "VMAccess virtual machine extension for Linux.",
+    "description": "The VMAccess virtual machine extensions for Linux allows the user to reset the password/ssh of a selected user or the ability to create a new local users with sudo access. https://github.com/Azure/azure-linux-extensions/blob/master/VMAccess/README.md",
+    "mode": "All",
+    "Metadata": {
+        "category": "Compute"
+    },
+    "Parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "description": "Enable or disable the execution of the policy",
+            "displayName": "Effect"
+          },
+          "allowedValues": [
+            "Audit",
+            "Deny",
+            "Disabled"
+          ],
+          "defaultValue": "Deny"
+        }
+      },
+    "policyRule": {
+        "if": {
+            "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.Compute/virtualMachines/extensions"
+                },
+                {
+                    "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                    "equals": "VMAccessForLinux"
+                }
+            ]
+        },
+        "then": {
+            "effect": "[parameters('effect')]"
+          }
+    }
+}

--- a/Policies/Compute/vm-extension-vmaccess/azurepolicy.json
+++ b/Policies/Compute/vm-extension-vmaccess/azurepolicy.json
@@ -1,41 +1,44 @@
 {
-    "displayName": "VMAccess virtual machine extension for Linux.",
+  "name": "97d4dc8b-b0bd-42da-aa83-bbf98c0c7ef7",
+  "properties": {
+    "displayName": "VMAccess virtual machine extension for Linux",
     "description": "The VMAccess virtual machine extensions for Linux allows the user to reset the password/ssh of a selected user or the ability to create a new local users with sudo access. https://github.com/Azure/azure-linux-extensions/blob/master/VMAccess/README.md",
-    "policyType": "Custom",
     "mode": "All",
     "Metadata": {
-        "category": "Compute"
+      "category": "Compute",
+      "version": "1.0.0"
     },
-    "Parameters": {
-        "effect": {
-          "type": "String",
-          "metadata": {
-            "description": "Enable or disable the execution of the policy",
-            "displayName": "Effect"
-          },
-          "allowedValues": [
-            "Audit",
-            "Deny",
-            "Disabled"
-          ],
-          "defaultValue": "Deny"
-        }
-      },
-    "policyRule": {
-        "if": {
-            "allOf": [
-                {
-                    "field": "type",
-                    "equals": "Microsoft.Compute/virtualMachines/extensions"
-                },
-                {
-                    "field": "Microsoft.Compute/virtualMachines/extensions/type",
-                    "equals": "VMAccessForLinux"
-                }
-            ]
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "description": "Enable or disable the execution of the policy",
+          "displayName": "Effect"
         },
-        "then": {
-            "effect": "[parameters('effect')]"
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Compute/virtualMachines/extensions"
+          },
+          {
+            "field": "Microsoft.Compute/virtualMachines/extensions/type",
+            "equals": "VMAccessForLinux"
           }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
     }
+  }
 }

--- a/Policies/Compute/vm-extension-vmaccess/azurepolicy.json
+++ b/Policies/Compute/vm-extension-vmaccess/azurepolicy.json
@@ -1,6 +1,7 @@
 {
     "displayName": "VMAccess virtual machine extension for Linux.",
     "description": "The VMAccess virtual machine extensions for Linux allows the user to reset the password/ssh of a selected user or the ability to create a new local users with sudo access. https://github.com/Azure/azure-linux-extensions/blob/master/VMAccess/README.md",
+    "policyType": "Custom",
     "mode": "All",
     "Metadata": {
         "category": "Compute"

--- a/Policies/Compute/vm-extension-vmaccess/azurepolicy.parameters.json
+++ b/Policies/Compute/vm-extension-vmaccess/azurepolicy.parameters.json
@@ -10,6 +10,6 @@
         "Deny",
         "Disabled"
       ],
-      "defaultValue": "Deny"
+      "defaultValue": "Audit"
     }
   }

--- a/Policies/Compute/vm-extension-vmaccess/azurepolicy.parameters.json
+++ b/Policies/Compute/vm-extension-vmaccess/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "description": "Enable or disable the execution of the policy",
+        "displayName": "Effect"
+      },
+      "allowedValues": [
+        "Audit",
+        "Deny",
+        "Disabled"
+      ],
+      "defaultValue": "Deny"
+    }
+  }

--- a/Policies/Compute/vm-extension-vmaccess/azurepolicy.rules.json
+++ b/Policies/Compute/vm-extension-vmaccess/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+    "if": {
+        "allOf": [
+            {
+                "field": "type",
+                "equals": "Microsoft.Compute/virtualMachines/extensions"
+            },
+            {
+                "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                "equals": "VMAccessForLinux"
+            }
+        ]
+    },
+    "then": {
+        "effect": "[parameters('effect')]"
+      }
+}


### PR DESCRIPTION
This Azure policy blocks/audits the usage of the VM Extension called "VMAccessForLinux".
VMAccessForLinux allows the user of the VM to reset the ssh key/password for an existing user or create a new user with a password/ssh key with sudo rights.

The process of reseting the password for users or generating a new user should be monitored and follow a defined process to avoid accidental/intentional elevation of rights in the operating system.