### PR TITLE
Adding azure policy for auditing/denying service endpoints on subnets.

### DIFF
--- a/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.json
+++ b/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.json
@@ -23,39 +23,23 @@
     },
     "policyRule": {
         "if": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "field": "type",
-                            "equals": "Microsoft.Network/virtualNetworks"
-                        },
-                        {
-                            "count": {
-                                "field": "Microsoft.Network/virtualNetworks/subnets[*]",
-                                "where": {
-                                    "field": "Microsoft.Network/virtualNetworks/subnets[*].serviceEndpoints[*].service",
-                                    "exists": true
-                                }
-                            },
-                            "greater": 0
-                        }
-                    ]
+            "allOf": [
+              {
+                "field": "type",
+                "equals": "Microsoft.Network/virtualNetworks/subnets"
+              },
+              {
+                "count": {
+                  "field": "Microsoft.Network/virtualNetworks/subnets/serviceEndpoints[*]",
+                  "where": {
+                    "field": "Microsoft.Network/virtualNetworks/subnets/serviceEndpoints[*].service",
+                    "exists": true
+                  }
                 },
-                {
-                    "allOf": [
-                        {
-                            "field": "type",
-                            "equals": "Microsoft.Network/virtualNetworks/subnets"
-                        },
-                        {
-                            "field": "Microsoft.Network/virtualNetworks/subnets/serviceEndpoints[*].service",
-                            "exists": true
-                        }
-                    ]
-                }
+                "greater": 0
+              }
             ]
-        },
+          },
         "then": {
             "effect": "[parameters('effect')]"
         }

--- a/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.json
+++ b/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.json
@@ -1,6 +1,7 @@
 {
     "mode": "All",
     "name": "Service Endpoints on Subnets",
+    "policyType": "Custom",
     "description": "This Policy will deny/audit Service Endpoints on subnets. Service Endpoints allows the network traffic to bypass Network appliances, such as the Azure Firewall.",
     "metadata": {
         "category": "Network"

--- a/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.json
+++ b/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.json
@@ -1,7 +1,7 @@
 {
     "mode": "All",
     "name": "Service Endpoints on Subnets",
-    "description": "This Policy will deny/audit Service Endpoints on subnets. Service Endpoints allows the network traffic to bypass Network appliances, such as the Azure Firewall and/or Network Security Group.",
+    "description": "This Policy will deny/audit Service Endpoints on subnets. Service Endpoints allows the network traffic to bypass Network appliances, such as the Azure Firewall.",
     "metadata": {
         "category": "Network"
     },

--- a/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.json
+++ b/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.json
@@ -1,0 +1,62 @@
+{
+    "mode": "All",
+    "name": "Service Endpoints on Subnets",
+    "description": "This Policy will deny/audit Service Endpoints on subnets. Service Endpoints allows the network traffic to bypass Network appliances, such as the Azure Firewall and/or Network Security Group.",
+    "metadata": {
+        "category": "Network"
+    },
+    "parameters": {
+        "effect": {
+            "type": "String",
+            "metadata": {
+                "displayName": "Effect",
+                "description": "Enable or disable the execution of the policy"
+            },
+            "allowedValues": [
+                "Audit",
+                "Deny",
+                "Disabled"
+            ],
+            "defaultValue": "Deny"
+        }
+    },
+    "policyRule": {
+        "if": {
+            "anyOf": [
+                {
+                    "allOf": [
+                        {
+                            "field": "type",
+                            "equals": "Microsoft.Network/virtualNetworks"
+                        },
+                        {
+                            "count": {
+                                "field": "Microsoft.Network/virtualNetworks/subnets[*]",
+                                "where": {
+                                    "field": "Microsoft.Network/virtualNetworks/subnets[*].serviceEndpoints[*].service",
+                                    "exists": true
+                                }
+                            },
+                            "greater": 0
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "field": "type",
+                            "equals": "Microsoft.Network/virtualNetworks/subnets"
+                        },
+                        {
+                            "field": "Microsoft.Network/virtualNetworks/subnets/serviceEndpoints[*].service",
+                            "exists": true
+                        }
+                    ]
+                }
+            ]
+        },
+        "then": {
+            "effect": "[parameters('effect')]"
+        }
+    }
+}

--- a/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.parameters.json
+++ b/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+    "effect": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+            "Audit",
+            "Deny",
+            "Disabled"
+        ],
+        "defaultValue": "Deny"
+    }
+}

--- a/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.rules.json
+++ b/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.rules.json
@@ -1,38 +1,22 @@
 {
     "if": {
-        "anyOf": [
-            {
-                "allOf": [
-                    {
-                        "field": "type",
-                        "equals": "Microsoft.Network/virtualNetworks"
-                    },
-                    {
-                        "count": {
-                            "field": "Microsoft.Network/virtualNetworks/subnets[*]",
-                            "where": {
-                                "field": "Microsoft.Network/virtualNetworks/subnets[*].serviceEndpoints[*].service",
-                                "exists": true
-                            }
-                        },
-                        "greater": 0
-                    }
-                ]
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/virtualNetworks/subnets"
+          },
+          {
+            "count": {
+              "field": "Microsoft.Network/virtualNetworks/subnets/serviceEndpoints[*]",
+              "where": {
+                "field": "Microsoft.Network/virtualNetworks/subnets/serviceEndpoints[*].service",
+                "exists": true
+              }
             },
-            {
-                "allOf": [
-                    {
-                        "field": "type",
-                        "equals": "Microsoft.Network/virtualNetworks/subnets"
-                    },
-                    {
-                        "field": "Microsoft.Network/virtualNetworks/subnets/serviceEndpoints[*].service",
-                        "exists": true
-                    }
-                ]
-            }
+            "greater": 0
+          }
         ]
-    },
+      },
     "then": {
         "effect": "[parameters('effect')]"
     }

--- a/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.rules.json
+++ b/Policies/Network/deny-vnet-subnet-serviceendpoints/azurepolicy.rules.json
@@ -1,0 +1,39 @@
+{
+    "if": {
+        "anyOf": [
+            {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Network/virtualNetworks"
+                    },
+                    {
+                        "count": {
+                            "field": "Microsoft.Network/virtualNetworks/subnets[*]",
+                            "where": {
+                                "field": "Microsoft.Network/virtualNetworks/subnets[*].serviceEndpoints[*].service",
+                                "exists": true
+                            }
+                        },
+                        "greater": 0
+                    }
+                ]
+            },
+            {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Network/virtualNetworks/subnets"
+                    },
+                    {
+                        "field": "Microsoft.Network/virtualNetworks/subnets/serviceEndpoints[*].service",
+                        "exists": true
+                    }
+                ]
+            }
+        ]
+    },
+    "then": {
+        "effect": "[parameters('effect')]"
+    }
+}


### PR DESCRIPTION
Adding Azure Policy to deny/audit Service endpoints on subnets.

-----------

Service endpoints on subnets allows resources to bypass virtual network appliances implemented and other network security features. Service endpoint enablement is a process which should be owned by the network team and have limited use.