### PR TITLE
New sql database policy shortterm backup retention policy

### DIFF
--- a/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.json
+++ b/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.json
@@ -1,0 +1,101 @@
+{
+    "properties": {
+        "displayName": "SQL DB Backup Retention",
+        "policyType": "custom",
+        "mode": "Indexed",
+        "description": "This policy modifies any Azure SQL Database to ensure a minimum number of retention days for short-term backups.",
+        "metadata": {
+            "version": "1.0.0",
+            "category": "SQL"
+        },
+        "parameters": {
+            "SqlDBBackupRetention.PolicyEffect": {
+                "type": "string",
+                "defaultValue": "DeployIfNotExists",
+                "allowedValues": [
+                    "AuditIfNotExists",
+                    "DeployIfNotExists",
+                    "Disabled"
+                ],
+                "metadata": {
+                    "displayName": "SqlDBBackupRetention.PolicyEffect",
+                    "description": "Enable or disable the execution of the policy"
+                }
+            },
+            "SqlDBBackupRetention.RetentionDays": {
+                "type": "integer",
+                "defaultValue": 7,
+                "metadata": {
+                    "displayName": "SqlDBBackupRetention.RetentionDays",
+                    "description": "Minimum number of days for short-term backup retention"
+                }
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Sql/servers/databases"
+                    },
+                    {
+                        "field": "name",
+                        "notEquals": "master"
+                    }
+                ]
+            },
+            "then": {
+                "effect": "[parameters('SqlDBBackupRetention.PolicyEffect')]",
+                "details": {
+                    "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
+                    "name": "default",
+                    "evaluationDelay": "AfterProvisioning",
+                    "roleDefinitionIds": [
+                        "/providers/microsoft.authorization/roleDefinitions/9b7fa17d-e63e-47b0-bb0a-15c516ac86ec",
+                        "/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3"
+                    ],
+                    "existenceCondition": {
+                        "field": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/retentionDays",
+                        "greaterOrEquals": "[parameters('SqlDBBackupRetention.RetentionDays')]"
+                    },
+                    "deployment": {
+                        "properties": {
+                            "mode": "incremental",
+                            "template": {
+                                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                "contentVersion": "1.0.0.0",
+                                "parameters": {
+                                    "fullDbName": {
+                                        "type": "string"
+                                    },
+                                    "retentionDays": {
+                                        "type": "int"
+                                    }
+                                },
+                                "resources": [
+                                    {
+                                        "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
+                                        "name": "[concat(parameters('fullDbName'), '/default')]",
+                                        "apiVersion": "2017-10-01-preview",
+                                        "properties": {
+                                            "retentionDays": "[parameters('retentionDays')]"
+                                        }
+                                    }
+                                ]
+                            },
+                            "parameters": {
+                                "fullDbName": {
+                                    "value": "[field('fullName')]"
+                                },
+                                "retentionDays": {
+                                    "value": "[parameters('SqlDBBackupRetention.RetentionDays')]"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "type": "Microsoft.Authorization/policyDefinitions"
+}

--- a/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.json
+++ b/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.json
@@ -9,7 +9,7 @@
             "category": "SQL"
         },
         "parameters": {
-            "SqlDBBackupRetention.PolicyEffect": {
+            "Effect": {
                 "type": "string",
                 "defaultValue": "DeployIfNotExists",
                 "allowedValues": [
@@ -18,7 +18,7 @@
                     "Disabled"
                 ],
                 "metadata": {
-                    "displayName": "SqlDBBackupRetention.PolicyEffect",
+                    "displayName": "PolicyEffect",
                     "description": "Enable or disable the execution of the policy"
                 }
             },
@@ -45,7 +45,7 @@
                 ]
             },
             "then": {
-                "effect": "[parameters('SqlDBBackupRetention.PolicyEffect')]",
+                "effect": "[parameters('Effect')]",
                 "details": {
                     "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
                     "name": "default",

--- a/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.json
+++ b/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.json
@@ -11,7 +11,7 @@
         "parameters": {
             "Effect": {
                 "type": "string",
-                "defaultValue": "DeployIfNotExists",
+                "defaultValue": "AuditIfNotExists",
                 "allowedValues": [
                     "AuditIfNotExists",
                     "DeployIfNotExists",

--- a/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.parameters.json
+++ b/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.parameters.json
@@ -1,0 +1,23 @@
+{
+    "SqlDBBackupRetention.PolicyEffect": {
+        "type": "string",
+        "defaultValue": "DeployIfNotExists",
+        "allowedValues": [
+            "AuditIfNotExists",
+            "DeployIfNotExists",
+            "Disabled"
+        ],
+        "metadata": {
+            "displayName": "SqlDBBackupRetention.PolicyEffect",
+            "description": "Enable or disable the execution of the policy"
+        }
+    },
+    "SqlDBBackupRetention.RetentionDays": {
+        "type": "integer",
+        "defaultValue": 7,
+        "metadata": {
+            "displayName": "SqlDBBackupRetention.RetentionDays",
+            "description": "Minimum number of days for short-term backup retention"
+        }
+    }
+}

--- a/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.parameters.json
+++ b/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.parameters.json
@@ -1,5 +1,5 @@
 {
-    "SqlDBBackupRetention.PolicyEffect": {
+    "Effect": {
         "type": "string",
         "defaultValue": "DeployIfNotExists",
         "allowedValues": [
@@ -8,7 +8,7 @@
             "Disabled"
         ],
         "metadata": {
-            "displayName": "SqlDBBackupRetention.PolicyEffect",
+            "displayName": "PolicyEffect",
             "description": "Enable or disable the execution of the policy"
         }
     },

--- a/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.rules.json
+++ b/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.rules.json
@@ -12,7 +12,7 @@
         ]
     },
     "then": {
-        "effect": "[parameters('SqlDBBackupRetention.PolicyEffect')]",
+        "effect": "[parameters('Effect')]",
         "details": {
             "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
             "name": "default",

--- a/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.rules.json
+++ b/Policies/SQL/deploy-sql-database-shortterm-backup-retention-policy/azurepolicy.rules.json
@@ -1,0 +1,65 @@
+{
+    "if": {
+        "allOf": [
+            {
+                "field": "type",
+                "equals": "Microsoft.Sql/servers/databases"
+            },
+            {
+                "field": "name",
+                "notEquals": "master"
+            }
+        ]
+    },
+    "then": {
+        "effect": "[parameters('SqlDBBackupRetention.PolicyEffect')]",
+        "details": {
+            "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
+            "name": "default",
+            "evaluationDelay": "AfterProvisioning",
+            "roleDefinitionIds": [
+                "/providers/microsoft.authorization/roleDefinitions/9b7fa17d-e63e-47b0-bb0a-15c516ac86ec",
+                "/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3"
+            ],
+            "existenceCondition": {
+                "field": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/retentionDays",
+                "greaterOrEquals": "[parameters('SqlDBBackupRetention.RetentionDays')]"
+            },
+            "deployment": {
+                "properties": {
+                    "mode": "incremental",
+                    "template": {
+                        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                        "contentVersion": "1.0.0.0",
+                        "parameters": {
+                            "fullDbName": {
+                                "type": "string"
+                            },
+                            "retentionDays": {
+                                "type": "int"
+                            }
+                        },
+                        "resources": [
+                            {
+                                "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
+                                "name": "[concat(parameters('fullDbName'), '/default')]",
+                                "apiVersion": "2017-10-01-preview",
+                                "properties": {
+                                    "retentionDays": "[parameters('retentionDays')]"
+                                }
+                            }
+                        ]
+                    },
+                    "parameters": {
+                        "fullDbName": {
+                            "value": "[field('fullName')]"
+                        },
+                        "retentionDays": {
+                            "value": "[parameters('SqlDBBackupRetention.RetentionDays')]"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding Azure Policy for Azure SQL Databases to deploy short-term backup retention policy if it does not exist.

Short-term retention policy is used to address point-in-time retention ability for near-term recovery of Azure SQL databases. It can be set to a number between 7-35 days for this retention policy. The default backup retention period under this policy is 7 days but it varies depending upon your pricing tier.

https://learn.microsoft.com/en-us/azure/azure-sql/database/temporal-tables-retention-policy?view=azuresql