### PR TITLE
Adding 4 new Azure Policies for SQL Server VMs

### DIFF
--- a/Policies/SQL/require-sql-server-vm-auto-backup/azurepolicy.json
+++ b/Policies/SQL/require-sql-server-vm-auto-backup/azurepolicy.json
@@ -14,7 +14,7 @@
             },
             {
               "field": "SqlVirtualMachine/sqlVirtualMachines/autoBackupSettings.enable",
-              "equals": "[parameters('keyVaultIntegrationSetting')]"
+              "equals": "[parameters('autoBackupSetting')]"
             }
           ]
         },

--- a/Policies/SQL/require-sql-server-vm-auto-backup/azurepolicy.json
+++ b/Policies/SQL/require-sql-server-vm-auto-backup/azurepolicy.json
@@ -1,0 +1,49 @@
+{
+    "name": "1b8b7328-ec3f-4196-a72b-39e66fdd17ad",
+    "properties": {
+      "displayName": "Require SQL Server VM Auto Backup",
+      "description": "Require SQL Server Virtual Machines to have Auto Backup enabled/disabled",
+      "policyType": "Custom",
+      "mode": "All",
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.SqlVirtualMachine/sqlVirtualMachines"
+            },
+            {
+              "field": "SqlVirtualMachine/sqlVirtualMachines/autoBackupSettings.enable",
+              "equals": "[parameters('keyVaultIntegrationSetting')]"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]"
+        }
+      },
+      "parameters": {
+        "autoBackupSetting": {
+          "type": "Boolean",
+          "metadata": {
+            "displayName": "Auto Backup Setting",
+            "description": "A boolean value for whether or not Auto Backup needs to be enabled on a SQL Server VM."
+          },
+          "defaultValue": false
+        },
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Audit, Deny, or Disable Auto Backup."
+          },
+          "allowedValues": [
+            "Audit",
+            "Deny",
+            "Disabled"
+          ],
+          "defaultValue": "Audit"
+        }
+      }
+    }
+  }

--- a/Policies/SQL/require-sql-server-vm-auto-backup/azurepolicy.parameters.json
+++ b/Policies/SQL/require-sql-server-vm-auto-backup/azurepolicy.parameters.json
@@ -1,0 +1,23 @@
+{
+    "autoBackupSetting": {
+      "type": "Boolean",
+      "metadata": {
+        "displayName": "Auto Backup Setting",
+        "description": "A boolean value for whether or not Auto Backup needs to be enabled on a SQL Server VM."
+      },
+      "defaultValue": false
+    },
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Audit, Deny, or Disable Auto Backup."
+      },
+      "allowedValues": [
+        "Audit",
+        "Deny",
+        "Disabled"
+      ],
+      "defaultValue": "Audit"
+    }
+}

--- a/Policies/SQL/require-sql-server-vm-auto-patching/azurepolicy.json
+++ b/Policies/SQL/require-sql-server-vm-auto-patching/azurepolicy.json
@@ -1,0 +1,49 @@
+{
+    "name": "0d37c5d2-dbeb-4f6e-a8f3-43dbdc4378c5",
+    "properties": {
+      "displayName": "Require SQL Server VM Auto Patching",
+      "description": "Require SQL Server Virtual Machines to have Auto Patching enabled/disabled",
+      "policyType": "Custom",
+      "mode": "All",
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.SqlVirtualMachine/sqlVirtualMachines"
+            },
+            {
+              "field": "Microsoft.SqlVirtualMachine/sqlVirtualMachines/autoPatchingSettings.enable",
+              "equals": "[parameters('autoPatchingSetting')]"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]"
+        }
+      },
+      "parameters": {
+        "autoPatchingSetting": {
+          "type": "Boolean",
+          "metadata": {
+            "displayName": "Auto Patching Setting",
+            "description": "A boolean value for whether or not Auto Patching needs to be enabled on a SQL Server VM."
+          },
+          "defaultValue": true
+        },
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Audit, Deny, or Disable Auto Patching."
+          },
+          "allowedValues": [
+            "Audit",
+            "Deny",
+            "Disabled"
+          ],
+          "defaultValue": "Audit"
+        }
+      }
+    }
+  }

--- a/Policies/SQL/require-sql-server-vm-auto-patching/azurepolicy.parameters.json
+++ b/Policies/SQL/require-sql-server-vm-auto-patching/azurepolicy.parameters.json
@@ -1,0 +1,23 @@
+{
+    "autoPatchingSetting": {
+      "type": "Boolean",
+      "metadata": {
+        "displayName": "Auto Patching Setting",
+        "description": "A boolean value for whether or not Auto Patching needs to be enabled on a SQL Server VM."
+      },
+      "defaultValue": true
+    },
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Audit, Deny, or Disable Auto Patching."
+      },
+      "allowedValues": [
+        "Audit",
+        "Deny",
+        "Disabled"
+      ],
+      "defaultValue": "Audit"
+    }
+}

--- a/Policies/SQL/require-sql-server-vm-key-vault-integration/azurepolicy.json
+++ b/Policies/SQL/require-sql-server-vm-key-vault-integration/azurepolicy.json
@@ -1,0 +1,49 @@
+{
+    "name": "25ccf510-be71-4094-89f4-d682affe1de5",
+    "properties": {
+      "displayName": "Require SQL Server VM Key Vault Integration",
+      "description": "Require SQL Server Virtual Machines to have Key Vault Integration",
+      "policyType": "Custom",
+      "mode": "All",
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.SqlVirtualMachine/sqlVirtualMachines"
+            },
+            {
+              "field": "Microsoft.SqlVirtualMachine/sqlVirtualMachines/keyVaultCredentialSettings.enable",
+              "equals": "[parameters('keyVaultIntegrationSetting')]"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]"
+        }
+      },
+      "parameters": {
+        "keyVaultIntegrationSetting": {
+          "type": "Boolean",
+          "metadata": {
+            "displayName": "Key Vault Integration Setting",
+            "description": "A boolean value for whether or not Key Vault Integration needs to be enabled on a SQL Server VM."
+          },
+          "defaultValue": false
+        },
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Audit, Deny, or Disable Key Vault Integration."
+          },
+          "allowedValues": [
+            "Audit",
+            "Deny",
+            "Disabled"
+          ],
+          "defaultValue": "Audit"
+        }
+      }
+    }
+  }

--- a/Policies/SQL/require-sql-server-vm-key-vault-integration/azurepolicy.parameters.json
+++ b/Policies/SQL/require-sql-server-vm-key-vault-integration/azurepolicy.parameters.json
@@ -1,0 +1,23 @@
+{
+    "keyVaultIntegrationSetting": {
+      "type": "Boolean",
+      "metadata": {
+        "displayName": "Key Vault Integration Setting",
+        "description": "A boolean value for whether or not Key Vault Integration needs to be enabled on a SQL Server VM."
+      },
+      "defaultValue": false
+    },
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Audit, Deny, or Disable Key Vault Integration."
+      },
+      "allowedValues": [
+        "Audit",
+        "Deny",
+        "Disabled"
+      ],
+      "defaultValue": "Audit"
+    }
+}

--- a/Policies/SQL/require-sql-server-vm-sql-connectivity/azurepolicy.json
+++ b/Policies/SQL/require-sql-server-vm-sql-connectivity/azurepolicy.json
@@ -23,7 +23,7 @@
         }
       },
       "parameters": {
-        "sqlConnectivitySetting": {
+        "sqlConnectivitySettings": {
           "type": "Array",
           "metadata": {
             "displayName": "SQL Connectivity Settings",

--- a/Policies/SQL/require-sql-server-vm-sql-connectivity/azurepolicy.json
+++ b/Policies/SQL/require-sql-server-vm-sql-connectivity/azurepolicy.json
@@ -14,7 +14,7 @@
             },
             {
               "field": "Microsoft.SqlVirtualMachine/sqlVirtualMachines/serverConfigurationsManagementSettings.sqlConnectivityUpdateSettings.connectivityType",
-              "notIn": "[parameters('sqlConnectivitySetting')]"
+              "notIn": "[parameters('sqlConnectivitySettings')]"
             }
           ]
         },

--- a/Policies/SQL/require-sql-server-vm-sql-connectivity/azurepolicy.json
+++ b/Policies/SQL/require-sql-server-vm-sql-connectivity/azurepolicy.json
@@ -1,0 +1,54 @@
+{
+    "name": "fdae7fa6-784c-4a97-ad40-4a34e1d0d70f",
+    "properties": {
+      "displayName": "Require SQL Server VM SQL Connectivity",
+      "description": "Require SQL Server Virtual Machines to have a specified SQL Connectivity setting applied",
+      "policyType": "Custom",
+      "mode": "All",
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.SqlVirtualMachine/sqlVirtualMachines"
+            },
+            {
+              "field": "Microsoft.SqlVirtualMachine/sqlVirtualMachines/serverConfigurationsManagementSettings.sqlConnectivityUpdateSettings.connectivityType",
+              "notIn": "[parameters('sqlConnectivitySetting')]"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]"
+        }
+      },
+      "parameters": {
+        "sqlConnectivitySetting": {
+          "type": "Array",
+          "metadata": {
+            "displayName": "SQL Connectivity Settings",
+            "description": "A list of acceptable SQL Connectivity Settings for your SQL Server Virtual Machine"
+          },
+          "allowedValues": [
+            "LOCAL",
+            "PRIVATE",
+            "PUBLIC"
+          ],
+          "defaultValue": "PUBLIC"
+        },
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Audit, Deny, or Disable the listed SQL Connectivity setting."
+          },
+          "allowedValues": [
+            "Audit",
+            "Deny",
+            "Disabled"
+          ],
+          "defaultValue": "Audit"
+        }
+      }
+    }
+  }

--- a/Policies/SQL/require-sql-server-vm-sql-connectivity/azurepolicy.parameters.json
+++ b/Policies/SQL/require-sql-server-vm-sql-connectivity/azurepolicy.parameters.json
@@ -1,5 +1,5 @@
 {
-    "sqlConnectivitySetting": {
+    "sqlConnectivitySettings": {
       "type": "Array",
       "metadata": {
         "displayName": "SQL Connectivity Settings",

--- a/Policies/SQL/require-sql-server-vm-sql-connectivity/azurepolicy.parameters.json
+++ b/Policies/SQL/require-sql-server-vm-sql-connectivity/azurepolicy.parameters.json
@@ -1,0 +1,28 @@
+{
+    "sqlConnectivitySetting": {
+      "type": "Array",
+      "metadata": {
+        "displayName": "SQL Connectivity Settings",
+        "description": "A list of acceptable SQL Connectivity Settings for your SQL Server Virtual Machine"
+      },
+      "allowedValues": [
+        "LOCAL",
+        "PRIVATE",
+        "PUBLIC"
+      ],
+      "defaultValue": "PUBLIC"
+    },
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Audit, Deny, or Disable the listed SQL Connectivity setting."
+      },
+      "allowedValues": [
+        "Audit",
+        "Deny",
+        "Disabled"
+      ],
+      "defaultValue": "Audit"
+    }
+}


### PR DESCRIPTION
Azure Policies
1. Require Key Vault Integration on SQL Server VM instances as a precursor to enabling Transparent Data Encryption (TDE).
2. Require Auto Patching so that the SQL Server VM can be up-to-date on the latest software and OS version.
3. Require Auto Backup so that the SQL Server VM can have its contents backed up on an Azure Storage Account Container.
4. Require SQL Connectivity setting so that users can toggle how the SQL Server VM accepts connections (Private, Public, Local).