### PR TITLE
Parameterized effect and added support for MDE ext

### DIFF
--- a/Policies/Compute/not-allowed-vmextension/azurepolicy.json
+++ b/Policies/Compute/not-allowed-vmextension/azurepolicy.json
@@ -1,36 +1,65 @@
 {
+    "name": "d7a36be7-42bc-4ea9-8029-2e8d4b8d175b",
+    "type": "Microsoft.Authorization/policyDefinitions",
     "properties": {
-        "displayName": "Not allowed VM Extensions",
-        "description": "This policy governs which VM extensions that are explicitly denied.",
-        "parameters": {
-            "notAllowedExtensions": {
-                "type": "Array",
-                "metadata": {
-                    "description": "The list of extensions that will be denied. Example: BGInfo, CustomScriptExtension, JsonAADDomainExtension, VMAccessAgent.",
-                    "displayName": "Denied extension"
-                }
-            }
+      "displayName": "Not allowed VM Extensions",
+      "description": "This policy governs which VM extensions that are explicitly denied.",
+      "metadata": {
+        "version": "2.0.0",
+        "category": "Compute"
+      },
+      "mode": "All",
+      "parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "The effect determines what happens when the policy rule is evaluated to match"
+          },
+          "allowedValues": [
+            "Audit",
+            "Deny",
+            "Disabled"
+          ],
+          "defaultValue": "Deny"
         },
-        "policyRule": {
-            "if": {
-                "allOf": [
-                    {
-                        "field": "type",
-                        "equals": "Microsoft.Compute/virtualMachines/extensions"
-                    },
-                    {
-                        "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
-                        "equals": "Microsoft.Compute"
-                    },
-                    {
-                        "field": "Microsoft.Compute/virtualMachines/extensions/type",
-                        "in": "[parameters('notAllowedExtensions')]"
-                    }
-                ]
-            },
-            "then": {
-                "effect": "deny"
-            }
+        "notAllowedExtensions": {
+          "type": "Array",
+          "metadata": {
+            "displayName": "Denied extension",
+            "description": "The list of extensions that will be denied."
+          }
         }
+      },
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Compute/virtualMachines/extensions"
+            },
+            {
+              "field": "Microsoft.Compute/virtualMachines/extensions/type",
+              "in": "[parameters('notAllowedExtensions')]"
+            },
+            {
+              "anyOf": [
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+                  "equals": "Microsoft.Azure.AzureDefenderForServers"
+                },
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+                  "equals": "Microsoft.Compute"
+                }
+              ]
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]"
+        }
+      }
     }
-}
+  }
+  

--- a/Policies/Compute/not-allowed-vmextension/azurepolicy.parameters.json
+++ b/Policies/Compute/not-allowed-vmextension/azurepolicy.parameters.json
@@ -1,9 +1,23 @@
 {
+	"effect": {
+	  "type": "String",
+	  "metadata": {
+		 "displayName": "Effect",
+		 "description": "The effect determines what happens when the policy rule is evaluated to match"
+	  },
+	  "allowedValues": [
+		 "Audit",
+		 "Deny",
+		 "Disabled"
+	  ],
+	  "defaultValue": "Deny"
+	},
 	"notAllowedExtensions": {
-		"type": "Array",
-		"metadata": {
-			"description": "The list of extensions that will be denied. Example: BGInfo, CustomScriptExtension, JsonAADDomainExtension, VMAccessAgent.",
-			"displayName": "Denied extension"
-		}
+	  "type": "Array",
+	  "metadata": {
+		 "displayName": "Denied extension",
+		 "description": "The list of extensions that will be denied."
+	  }
 	}
-}
+ }
+ 

--- a/Policies/Compute/not-allowed-vmextension/azurepolicy.rules.json
+++ b/Policies/Compute/not-allowed-vmextension/azurepolicy.rules.json
@@ -1,21 +1,30 @@
 {
 	"if": {
-		"allOf": [
-			{
-				"field": "type",
-				"equals": "Microsoft.Compute/virtualMachines/extensions"
-			},
-			{
-				"field": "Microsoft.Compute/virtualMachines/extensions/publisher",
-				"equals": "Microsoft.Compute"
-			},
-			{
-				"field": "Microsoft.Compute/virtualMachines/extensions/type",
-				"in": "[parameters('notAllowedExtensions')]"
-			}
-		]
+	  "allOf": [
+		 {
+			"field": "type",
+			"equals": "Microsoft.Compute/virtualMachines/extensions"
+		 },
+		 {
+			"field": "Microsoft.Compute/virtualMachines/extensions/type",
+			"in": "[parameters('notAllowedExtensions')]"
+		 },
+		 {
+			"anyOf": [
+			  {
+				 "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+				 "equals": "Microsoft.Azure.AzureDefenderForServers"
+			  },
+			  {
+				 "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+				 "equals": "Microsoft.Compute"
+			  }
+			]
+		 }
+	  ]
 	},
 	"then": {
-		"effect": "deny"
+	  "effect": "[parameters('effect')]"
 	}
-}
+ }
+ 


### PR DESCRIPTION
Parameterized the effect as well as added support to block Defender for Endpoint (MDE.Windows / MDE.Linux) extension, if you for example want to run Defender for Servers without enabling MDE