### PR TITLE
2 policies for APIM audit sample products and deny external VPN

### DIFF
--- a/Policies/APIManagement/Audit - Sample Products should be removed from API Management/Audit - Sample Products should be removed from API Management.json
+++ b/Policies/APIManagement/Audit - Sample Products should be removed from API Management/Audit - Sample Products should be removed from API Management.json
@@ -1,0 +1,44 @@
+{
+  "name": "f9869580-d1e9-491a-91b5-d212d8acd27e",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Audit - Sample Products should be removed from API Management",
+    "description": "API Management includes two sample products Starter and Unlimited. Accidentally adding APIs to these sample products may expose APIs more than intended.",
+    "metadata": {
+      "category": "API Management",
+      "version": "1.0.0"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect of policy",
+          "description": "Audit, disable"
+        },
+        "allowedValues": [
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "anyOf": [
+          {
+            "field": "Microsoft.ApiManagement/service/products/displayName",
+            "equals": "Starter"
+          },
+          {
+            "field": "Microsoft.ApiManagement/service/products/displayName",
+            "equals": "Unlimited"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/APIManagement/Audit - Sample Products should be removed from API Management/Audit - Sample Products should be removed from API Management.parameters.json
+++ b/Policies/APIManagement/Audit - Sample Products should be removed from API Management/Audit - Sample Products should be removed from API Management.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect of policy",
+      "description": "Audit, disable"
+    },
+    "allowedValues": [
+      "Audit",
+      "Disabled"
+    ],
+    "defaultValue": "Audit"
+  }
+}

--- a/Policies/APIManagement/Audit - Sample Products should be removed from API Management/Audit - Sample Products should be removed from API Management.rules.json
+++ b/Policies/APIManagement/Audit - Sample Products should be removed from API Management/Audit - Sample Products should be removed from API Management.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "anyOf": [
+      {
+        "field": "Microsoft.ApiManagement/service/products/displayName",
+        "equals": "Starter"
+      },
+      {
+        "field": "Microsoft.ApiManagement/service/products/displayName",
+        "equals": "Unlimited"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/APIManagement/Deny - Enforcing Internal VPN/Deny - Enforcing Internal VPN.json
+++ b/Policies/APIManagement/Deny - Enforcing Internal VPN/Deny - Enforcing Internal VPN.json
@@ -1,0 +1,45 @@
+{
+  "name": "b525e077-ad27-4116-bdd1-83cfa9c86bfc",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Deny - Enforcing Internal VPN",
+    "description": "The policy enforces the API Manager resource to be deployed in an Internal Virtual Private Network. No Public EndPoint, no External VPN.",
+    "metadata": {
+      "category": "API Management",
+      "version": "1.0.0"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "Deny",
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Deny"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.ApiManagement/service"
+          },
+          {
+            "field": "Microsoft.ApiManagement/service/virtualNetworkType",
+            "notEquals": "Internal"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/APIManagement/Deny - Enforcing Internal VPN/Deny - Enforcing Internal VPN.parameters.json
+++ b/Policies/APIManagement/Deny - Enforcing Internal VPN/Deny - Enforcing Internal VPN.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "Deny",
+      "Audit",
+      "Disabled"
+    ],
+    "defaultValue": "Deny"
+  }
+}

--- a/Policies/APIManagement/Deny - Enforcing Internal VPN/Deny - Enforcing Internal VPN.rules.json
+++ b/Policies/APIManagement/Deny - Enforcing Internal VPN/Deny - Enforcing Internal VPN.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.ApiManagement/service"
+      },
+      {
+        "field": "Microsoft.ApiManagement/service/virtualNetworkType",
+        "notEquals": "Internal"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/Monitoring/Diag2LAW/Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace/Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace.json
+++ b/Policies/Monitoring/Diag2LAW/Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace/Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace.json
@@ -1,0 +1,181 @@
+{
+  "name": "8edaf2b5-dcb7-4b8a-8cf9-6fce65292e07",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace",
+    "description": "Deploys the diagnostic settings for Managed HSM Key Vaults to stream to a Log Analytics workspace when any Managed HSM Key Vault which is missing this diagnostic settings is created or updated. The policy will set the diagnostic with all metrics and category enabled.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Monitoring"
+    },
+    "mode": "Indexed",
+    "parameters": {
+      "logAnalytics": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Log Analytics workspace",
+          "description": "Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.",
+          "strongType": "omsWorkspace"
+        }
+      },
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "DeployIfNotExists",
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists"
+      },
+      "profileName": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Profile name",
+          "description": "The diagnostic settings profile name"
+        },
+        "defaultValue": "setbypolicy_logAnalytics"
+      },
+      "metricsEnabled": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Enable metrics",
+          "description": "Whether to enable metrics stream to the Log Analytics workspace - True or False"
+        },
+        "allowedValues": [
+          "True",
+          "False"
+        ],
+        "defaultValue": "True"
+      },
+      "logsEnabled": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Enable logs",
+          "description": "Whether to enable logs stream to the Log Analytics workspace - True or False"
+        },
+        "allowedValues": [
+          "True",
+          "False"
+        ],
+        "defaultValue": "True"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "field": "type",
+        "equals": "microsoft.keyvault/managedhsms"
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.Insights/diagnosticSettings",
+          "name": "[parameters('profileName')]",
+          "existenceCondition": {
+            "allOf": [
+              {
+                "field": "Microsoft.Insights/diagnosticSettings/logs.enabled",
+                "equals": "true"
+              },
+              {
+                "field": "Microsoft.Insights/diagnosticSettings/metrics.enabled",
+                "equals": "true"
+              },
+              {
+                "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
+                "equals": "[parameters('logAnalytics')]"
+              }
+            ]
+          },
+          "roleDefinitionIds": [
+            "/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa",
+            "/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293"
+          ],
+          "deployment": {
+            "properties": {
+              "mode": "Incremental",
+              "template": {
+                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {
+                  "resourceName": {
+                    "type": "String"
+                  },
+                  "logAnalytics": {
+                    "type": "String"
+                  },
+                  "location": {
+                    "type": "String"
+                  },
+                  "profileName": {
+                    "type": "String"
+                  },
+                  "metricsEnabled": {
+                    "type": "String"
+                  },
+                  "logsEnabled": {
+                    "type": "String"
+                  }
+                },
+                "variables": {},
+                "resources": [
+                  {
+                    "type": "Microsoft.Network/applicationInsights/providers/diagnosticSettings",
+                    "apiVersion": "2021-05-01-preview",
+                    "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [],
+                    "properties": {
+                      "workspaceId": "[parameters('logAnalytics')]",
+                      "metrics": [
+                        {
+                          "category": "AllMetrics",
+                          "enabled": "[parameters('metricsEnabled')]",
+                          "retentionPolicy": {
+                            "days": 0,
+                            "enabled": false
+                          },
+                          "timeGrain": null
+                        }
+                      ],
+                      "logs": [
+                        {
+                          "category": "AuditEvent",
+                          "enabled": "[parameters('logsEnabled')]"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "outputs": {}
+              },
+              "parameters": {
+                "logAnalytics": {
+                  "value": "[parameters('logAnalytics')]"
+                },
+                "location": {
+                  "value": "[field('location')]"
+                },
+                "resourceName": {
+                  "value": "[field('name')]"
+                },
+                "profileName": {
+                  "value": "[parameters('profileName')]"
+                },
+                "metricsEnabled": {
+                  "value": "[parameters('metricsEnabled')]"
+                },
+                "logsEnabled": {
+                  "value": "[parameters('logsEnabled')]"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Policies/Monitoring/Diag2LAW/Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace/Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace.parameters.json
+++ b/Policies/Monitoring/Diag2LAW/Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace/Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace.parameters.json
@@ -1,0 +1,55 @@
+{
+  "logAnalytics": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Log Analytics workspace",
+      "description": "Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.",
+      "strongType": "omsWorkspace"
+    }
+  },
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "DeployIfNotExists",
+      "AuditIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "DeployIfNotExists"
+  },
+  "profileName": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Profile name",
+      "description": "The diagnostic settings profile name"
+    },
+    "defaultValue": "setbypolicy_logAnalytics"
+  },
+  "metricsEnabled": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Enable metrics",
+      "description": "Whether to enable metrics stream to the Log Analytics workspace - True or False"
+    },
+    "allowedValues": [
+      "True",
+      "False"
+    ],
+    "defaultValue": "True"
+  },
+  "logsEnabled": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Enable logs",
+      "description": "Whether to enable logs stream to the Log Analytics workspace - True or False"
+    },
+    "allowedValues": [
+      "True",
+      "False"
+    ],
+    "defaultValue": "True"
+  }
+}

--- a/Policies/Monitoring/Diag2LAW/Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace/Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace.rules.json
+++ b/Policies/Monitoring/Diag2LAW/Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace/Deploy Diagnostic Settings for Managed HSM Key Vault to Log Analytics workspace.rules.json
@@ -1,0 +1,113 @@
+{
+  "if": {
+    "field": "type",
+    "equals": "microsoft.keyvault/managedhsms"
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Insights/diagnosticSettings",
+      "name": "[parameters('profileName')]",
+      "existenceCondition": {
+        "allOf": [
+          {
+            "field": "Microsoft.Insights/diagnosticSettings/logs.enabled",
+            "equals": "true"
+          },
+          {
+            "field": "Microsoft.Insights/diagnosticSettings/metrics.enabled",
+            "equals": "true"
+          },
+          {
+            "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
+            "equals": "[parameters('logAnalytics')]"
+          }
+        ]
+      },
+      "roleDefinitionIds": [
+        "/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa",
+        "/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "Incremental",
+          "template": {
+            "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "resourceName": {
+                "type": "String"
+              },
+              "logAnalytics": {
+                "type": "String"
+              },
+              "location": {
+                "type": "String"
+              },
+              "profileName": {
+                "type": "String"
+              },
+              "metricsEnabled": {
+                "type": "String"
+              },
+              "logsEnabled": {
+                "type": "String"
+              }
+            },
+            "variables": {},
+            "resources": [
+              {
+                "type": "Microsoft.Network/applicationInsights/providers/diagnosticSettings",
+                "apiVersion": "2021-05-01-preview",
+                "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]",
+                "location": "[parameters('location')]",
+                "dependsOn": [],
+                "properties": {
+                  "workspaceId": "[parameters('logAnalytics')]",
+                  "metrics": [
+                    {
+                      "category": "AllMetrics",
+                      "enabled": "[parameters('metricsEnabled')]",
+                      "retentionPolicy": {
+                        "days": 0,
+                        "enabled": false
+                      },
+                      "timeGrain": null
+                    }
+                  ],
+                  "logs": [
+                    {
+                      "category": "AuditEvent",
+                      "enabled": "[parameters('logsEnabled')]"
+                    }
+                  ]
+                }
+              }
+            ],
+            "outputs": {}
+          },
+          "parameters": {
+            "logAnalytics": {
+              "value": "[parameters('logAnalytics')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            },
+            "resourceName": {
+              "value": "[field('name')]"
+            },
+            "profileName": {
+              "value": "[parameters('profileName')]"
+            },
+            "metricsEnabled": {
+              "value": "[parameters('metricsEnabled')]"
+            },
+            "logsEnabled": {
+              "value": "[parameters('logsEnabled')]"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The first policy is to audit because API Management includes two sample products 'Starter' and 'Unlimited'. Accidentally adding APIs to these sample products may expose APIs more than intended.

The next policy enforces the API Manager resource to be deployed in an Internal Virtual Private Network. No Public EndPoint, no External VPN.