### PR TITLE
Added policies to control policy exemption details

### DIFF
--- a/Policies/Authorization/Deny policy exemption with an expiration date greater than given days/Deny policy exemption with an expiration date greater than given days.json
+++ b/Policies/Authorization/Deny policy exemption with an expiration date greater than given days/Deny policy exemption with an expiration date greater than given days.json
@@ -1,0 +1,52 @@
+{
+  "name": "e480d649-32e9-423e-b6ce-e99656cd52e2",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Deny policy exemption with an expiration date greater than given days",
+    "description": "Deny policy exemption with an expiration date greater than given days",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Policy"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the audit policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny"
+      },
+      "maxExpirationDays": {
+        "type": "integer",
+        "defaultValue": 182,
+        "metadata": {
+          "description": "Days from current datetime that a policy exemption date can maximum be. Time is UTC. 182 is approx. 6 months."
+        }
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Authorization/policyExemptions"
+          },
+          {
+            "field": "Microsoft.Authorization/policyExemptions/expiresOn",
+            "greaterOrEquals": "[addDays(utcNow(), parameters('maxExpirationDays'))]"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/Authorization/Deny policy exemption with an expiration date greater than given days/Deny policy exemption with an expiration date greater than given days.parameters.json
+++ b/Policies/Authorization/Deny policy exemption with an expiration date greater than given days/Deny policy exemption with an expiration date greater than given days.parameters.json
@@ -1,0 +1,22 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the audit policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Deny",
+      "Disabled"
+    ],
+    "defaultValue": "Deny"
+  },
+  "maxExpirationDays": {
+    "type": "integer",
+    "defaultValue": 182,
+    "metadata": {
+      "description": "Days from current datetime that a policy exemption date can maximum be. Time is UTC. 182 is approx. 6 months."
+    }
+  }
+}

--- a/Policies/Authorization/Deny policy exemption with an expiration date greater than given days/Deny policy exemption with an expiration date greater than given days.rules.json
+++ b/Policies/Authorization/Deny policy exemption with an expiration date greater than given days/Deny policy exemption with an expiration date greater than given days.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Authorization/policyExemptions"
+      },
+      {
+        "field": "Microsoft.Authorization/policyExemptions/expiresOn",
+        "greaterOrEquals": "[addDays(utcNow(), parameters('maxExpirationDays'))]"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/Authorization/Deny policy exemption without description/Deny policy exemption without description.json
+++ b/Policies/Authorization/Deny policy exemption without description/Deny policy exemption without description.json
@@ -1,0 +1,45 @@
+{
+  "name": "d9242b7d-b537-4d67-9bf8-5a6021e25cfa",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Deny policy exemption without description",
+    "description": "Deny policy exemption without description",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Policy"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the audit policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Authorization/policyExemptions"
+          },
+          {
+            "field": "Microsoft.Authorization/policyExemptions/description",
+            "exists": false
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/Authorization/Deny policy exemption without description/Deny policy exemption without description.parameters.json
+++ b/Policies/Authorization/Deny policy exemption without description/Deny policy exemption without description.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the audit policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Deny",
+      "Disabled"
+    ],
+    "defaultValue": "Deny"
+  }
+}

--- a/Policies/Authorization/Deny policy exemption without description/Deny policy exemption without description.rules.json
+++ b/Policies/Authorization/Deny policy exemption without description/Deny policy exemption without description.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Authorization/policyExemptions"
+      },
+      {
+        "field": "Microsoft.Authorization/policyExemptions/description",
+        "exists": false
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/Authorization/Deny policy exemption without expiration date/Deny policy exemption without expiration date.json
+++ b/Policies/Authorization/Deny policy exemption without expiration date/Deny policy exemption without expiration date.json
@@ -1,0 +1,45 @@
+{
+  "name": "68e5104c-f69f-44b5-b474-9bf5b662451f",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Deny policy exemption without expiration date",
+    "description": "Deny policy exemption without expiration date",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Policy"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the audit policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Authorization/policyExemptions"
+          },
+          {
+            "field": "Microsoft.Authorization/policyExemptions/expiresOn",
+            "exists": false
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/Authorization/Deny policy exemption without expiration date/Deny policy exemption without expiration date.parameters.json
+++ b/Policies/Authorization/Deny policy exemption without expiration date/Deny policy exemption without expiration date.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the audit policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Deny",
+      "Disabled"
+    ],
+    "defaultValue": "Deny"
+  }
+}

--- a/Policies/Authorization/Deny policy exemption without expiration date/Deny policy exemption without expiration date.rules.json
+++ b/Policies/Authorization/Deny policy exemption without expiration date/Deny policy exemption without expiration date.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Authorization/policyExemptions"
+      },
+      {
+        "field": "Microsoft.Authorization/policyExemptions/expiresOn",
+        "exists": false
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/Authorization/Deny policy exemption without given info/Deny policy exemption without given info.json
+++ b/Policies/Authorization/Deny policy exemption without given info/Deny policy exemption without given info.json
@@ -1,0 +1,64 @@
+{
+  "name": "540c5c99-3197-431b-a70c-0410029e87e4",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Deny policy exemption without given info",
+    "description": "Deny policy exemption if expiration date is not set, if an expiration date greater than given days, or if description is empty",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Policy"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the audit policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Deny"
+      },
+      "maxExpirationDays": {
+        "type": "integer",
+        "defaultValue": 182,
+        "metadata": {
+          "description": "Days from current datetime that a policy exemption date can maximum be. Time is UTC. 182 is approx. 6 months."
+        }
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Authorization/policyExemptions"
+          },
+          {
+            "anyOf": [
+              {
+                "field": "Microsoft.Authorization/policyExemptions/expiresOn",
+                "exists": false
+              },
+              {
+                "field": "Microsoft.Authorization/policyExemptions/expiresOn",
+                "greaterOrEquals": "[addDays(utcNow(), parameters('maxExpirationDays'))]"
+              },
+              {
+                "field": "Microsoft.Authorization/policyExemptions/description",
+                "exists": false
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/Authorization/Deny policy exemption without given info/Deny policy exemption without given info.parameters.json
+++ b/Policies/Authorization/Deny policy exemption without given info/Deny policy exemption without given info.parameters.json
@@ -1,0 +1,22 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the audit policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Deny",
+      "Disabled"
+    ],
+    "defaultValue": "Deny"
+  },
+  "maxExpirationDays": {
+    "type": "integer",
+    "defaultValue": 182,
+    "metadata": {
+      "description": "Days from current datetime that a policy exemption date can maximum be. Time is UTC. 182 is approx. 6 months."
+    }
+  }
+}

--- a/Policies/Authorization/Deny policy exemption without given info/Deny policy exemption without given info.rules.json
+++ b/Policies/Authorization/Deny policy exemption without given info/Deny policy exemption without given info.rules.json
@@ -1,0 +1,29 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Authorization/policyExemptions"
+      },
+      {
+        "anyOf": [
+          {
+            "field": "Microsoft.Authorization/policyExemptions/expiresOn",
+            "exists": false
+          },
+          {
+            "field": "Microsoft.Authorization/policyExemptions/expiresOn",
+            "greaterOrEquals": "[addDays(utcNow(), parameters('maxExpirationDays'))]"
+          },
+          {
+            "field": "Microsoft.Authorization/policyExemptions/description",
+            "exists": false
+          }
+        ]
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}


### PR DESCRIPTION
4 different policies to control that a policy exemption has the detailed described in the policies otherwise it will deny the creation.
Cannot create a policy exemption without:
- description
- expiration date
- expiration date cannot be greater than X-days
And 1 policy to combine the above 3 points.