### PR TITLE
Deny data access auth mode

### DIFF
--- a/Policies/Compute/Deny data access authentication mode/Deny data access authentication mode.json
+++ b/Policies/Compute/Deny data access authentication mode/Deny data access authentication mode.json
@@ -1,0 +1,45 @@
+{
+  "name": "578b0370-4e9e-4a25-b24e-3964c4003955",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Deny data access authentication mode",
+    "description": "Disable data access authentication mode to restrict access to export the disk. https://learn.microsoft.com/en-us/azure/virtual-machines/windows/download-vhd?tabs=azure-portal#secure-downloads-and-uploads-with-azure-ad",
+    "metadata": {
+      "category": "Compute",
+      "version": "1.0.0"
+    },
+    "mode": "Indexed",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Disabled",
+          "Deny"
+        ],
+        "defaultValue": "Deny"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Compute/disks"
+          },
+          {
+            "field": "Microsoft.Compute/disks/dataAccessAuthmode",
+            "equals": "AzureActiveDirectory"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/Compute/Deny data access authentication mode/Deny data access authentication mode.parameters.json
+++ b/Policies/Compute/Deny data access authentication mode/Deny data access authentication mode.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Disabled",
+      "Deny"
+    ],
+    "defaultValue": "Deny"
+  }
+}

--- a/Policies/Compute/Deny data access authentication mode/Deny data access authentication mode.rules.json
+++ b/Policies/Compute/Deny data access authentication mode/Deny data access authentication mode.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Compute/disks"
+      },
+      {
+        "field": "Microsoft.Compute/disks/dataAccessAuthmode",
+        "equals": "AzureActiveDirectory"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}


### PR DESCRIPTION
Disable data access authentication mode to restrict access to export the disk. https://learn.microsoft.com/en-us/azure/virtual-machines/windows/download-vhd?tabs=azure-portal#secure-downloads-and-uploads-with-azure-ad
A supplement to export data disks but in some cases you might not want to have RBAC enabled for disk export.