### PR TITLE
Deny on Configuring Event Hubs

### DIFF
--- a/Policies/EventHub/Deny - Configure Event Hubs to allow only certain SKUs/azurepolicy.json
+++ b/Policies/EventHub/Deny - Configure Event Hubs to allow only certain SKUs/azurepolicy.json
@@ -1,0 +1,56 @@
+{
+  "name": "33e7e8f1-ea02-4dd0-911d-0fbe0d54d427",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Deny - Configure Event Hubs to allow only certain SKUs",
+    "description": "The policy denies the Basic SKU because one can only create private endpoint connections with Standard or Premium SKU.",
+    "metadata": {
+      "category": "Event Hub",
+      "version": "1.0.0"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Disabled",
+          "Deny"
+        ],
+        "defaultValue": "Deny"
+      },
+      "allowedSkuNames": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Allowed SKU Names",
+          "description": "Specifies the allowed SKU names."
+        },
+        "defaultValue": [
+          "Standard",
+          "Premium"
+        ]
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.EventHub/namespaces"
+          },
+          {
+            "field": "Microsoft.EventHub/namespaces/sku.name",
+            "notIn": "[parameters('allowedSkuNames')]"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/EventHub/Deny - Configure Event Hubs to allow only certain SKUs/azurepolicy.parameters.json
+++ b/Policies/EventHub/Deny - Configure Event Hubs to allow only certain SKUs/azurepolicy.parameters.json
@@ -1,0 +1,26 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Disabled",
+      "Deny"
+    ],
+    "defaultValue": "Deny"
+  },
+  "allowedSkuNames": {
+    "type": "Array",
+    "metadata": {
+      "displayName": "Allowed SKU Names",
+      "description": "Specifies the allowed SKU names."
+    },
+    "defaultValue": [
+      "Standard",
+      "Premium"
+    ]
+  }
+}

--- a/Policies/EventHub/Deny - Configure Event Hubs to allow only certain SKUs/azurepolicy.rules.json
+++ b/Policies/EventHub/Deny - Configure Event Hubs to allow only certain SKUs/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.EventHub/namespaces"
+      },
+      {
+        "field": "Microsoft.EventHub/namespaces/sku.name",
+        "notIn": "[parameters('allowedSkuNames')]"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/EventHub/Deny - Configure Event Hubs to disable public network access/azurepolicy.json
+++ b/Policies/EventHub/Deny - Configure Event Hubs to disable public network access/azurepolicy.json
@@ -1,0 +1,45 @@
+{
+  "name": "f6006471-31cf-4887-a7cb-42724faed672",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Deny - Configure Event Hubs to disable public network access",
+    "description": "The policy denies accessing the resource through public network. Only private endpoints are supported.",
+    "metadata": {
+      "category": "Event Hub",
+      "version": "1.0.0"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "Deny",
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Deny"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.EventHub/namespaces"
+          },
+          {
+            "field": "Microsoft.EventHub/namespaces/publicNetworkAccess",
+            "notEquals": "Disabled"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/EventHub/Deny - Configure Event Hubs to disable public network access/azurepolicy.parameters.json
+++ b/Policies/EventHub/Deny - Configure Event Hubs to disable public network access/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "Deny",
+      "Audit",
+      "Disabled"
+    ],
+    "defaultValue": "Deny"
+  }
+}

--- a/Policies/EventHub/Deny - Configure Event Hubs to disable public network access/azurepolicy.rules.json
+++ b/Policies/EventHub/Deny - Configure Event Hubs to disable public network access/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.EventHub/namespaces"
+      },
+      {
+        "field": "Microsoft.EventHub/namespaces/publicNetworkAccess",
+        "notEquals": "Disabled"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/EventHub/Deny - Configure Event Hubs to use availability zones/azurepolicy.json
+++ b/Policies/EventHub/Deny - Configure Event Hubs to use availability zones/azurepolicy.json
@@ -1,0 +1,45 @@
+{
+  "name": "b47a96dc-ce80-49f5-8718-bee39c051a4b",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Deny - Configure Event Hubs to use availability zones",
+    "description": "The policy enforces the usage of regions with availability zones. With availability zones high availability is provided.",
+    "metadata": {
+      "category": "Event Hub",
+      "version": "1.0.0"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "Disabled",
+          "Audit",
+          "Deny"
+        ],
+        "defaultValue": "Deny"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.EventHub/namespaces"
+          },
+          {
+            "field": "Microsoft.EventHub/namespaces/zoneRedundant",
+            "notEquals": true
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/EventHub/Deny - Configure Event Hubs to use availability zones/azurepolicy.parameters.json
+++ b/Policies/EventHub/Deny - Configure Event Hubs to use availability zones/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "Disabled",
+      "Audit",
+      "Deny"
+    ],
+    "defaultValue": "Deny"
+  }
+}

--- a/Policies/EventHub/Deny - Configure Event Hubs to use availability zones/azurepolicy.rules.json
+++ b/Policies/EventHub/Deny - Configure Event Hubs to use availability zones/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.EventHub/namespaces"
+      },
+      {
+        "field": "Microsoft.EventHub/namespaces/zoneRedundant",
+        "notEquals": true
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}


### PR DESCRIPTION
Adding 3 policies to deny wrong configuration on Event Hubs for different scenarios.
See policy descriptions for further info.