### PR TITLE
Compute policies for auditing images and BYOL

### DIFF
--- a/Policies/Compute/Deny Windows VM or VMSS without BYOL/azurepolicy.json
+++ b/Policies/Compute/Deny Windows VM or VMSS without BYOL/azurepolicy.json
@@ -1,0 +1,77 @@
+{
+  "name": "63b4e328-7369-4a72-a5ad-0884d7fb1d04",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Deny Windows VM or VMSS without BYOL",
+    "description": "The policy checks if VMs or VM Scale Sets based on Microsoft operation system is using BYOL for Azure Hybrid Benefit. The decision if VM is based on Microsoft OS or not is based on the following policy:\n[Preview]: Azure Security agent should be installed on your Windows virtual machines - Microsoft Azure\nhttps://portal.azure.com/#view/Microsoft_Azure_Policy/PolicyDetailBlade/definitionId/%2Fproviders%2FMicrosoft.Authorization%2FpolicyDefinitions%2Fbb2c6c6d-14bc-4443-bef3-c6be0adc6076",
+    "metadata": {
+      "category": "Compute",
+      "version": "1.0.0"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "effect",
+          "description": "It is essential to have the proper effect."
+        },
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "in": [
+              "Microsoft.Compute/virtualMachineScaleSets",
+              "Microsoft.Compute/virtualMachines"
+            ]
+          },
+          {
+            "anyOf": [
+              {
+                "field": "Microsoft.Compute/imagePublisher",
+                "contains": "Microsoft"
+              },
+              {
+                "field": "Microsoft.Compute/imagePublisher",
+                "contains": "Windows"
+              },
+              {
+                "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
+                "contains": "Windows"
+              }
+            ]
+          },
+          {
+            "anyOf": [
+              {
+                "field": "Microsoft.Compute/licenseType",
+                "exists": false
+              },
+              {
+                "not": {
+                  "field": "Microsoft.Compute/licenseType",
+                  "in": [
+                    "Windows_Server",
+                    "Windows_Client"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/Compute/Deny Windows VM or VMSS without BYOL/azurepolicy.parameters.json
+++ b/Policies/Compute/Deny Windows VM or VMSS without BYOL/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "effect",
+      "description": "It is essential to have the proper effect."
+    },
+    "allowedValues": [
+      "Audit",
+      "Deny",
+      "Disabled"
+    ],
+    "defaultValue": "Audit"
+  }
+}

--- a/Policies/Compute/Deny Windows VM or VMSS without BYOL/azurepolicy.rules.json
+++ b/Policies/Compute/Deny Windows VM or VMSS without BYOL/azurepolicy.rules.json
@@ -1,0 +1,49 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "in": [
+          "Microsoft.Compute/virtualMachineScaleSets",
+          "Microsoft.Compute/virtualMachines"
+        ]
+      },
+      {
+        "anyOf": [
+          {
+            "field": "Microsoft.Compute/imagePublisher",
+            "contains": "Microsoft"
+          },
+          {
+            "field": "Microsoft.Compute/imagePublisher",
+            "contains": "Windows"
+          },
+          {
+            "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
+            "contains": "Windows"
+          }
+        ]
+      },
+      {
+        "anyOf": [
+          {
+            "field": "Microsoft.Compute/licenseType",
+            "exists": false
+          },
+          {
+            "not": {
+              "field": "Microsoft.Compute/licenseType",
+              "in": [
+                "Windows_Server",
+                "Windows_Client"
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/Compute/audit-vms-based-on-marketplace-images/azurepolicy.json
+++ b/Policies/Compute/audit-vms-based-on-marketplace-images/azurepolicy.json
@@ -1,0 +1,45 @@
+{
+  "name": "a091018b-fd0b-4898-92e1-d0b0a960e1eb",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "audit-vms-based-on-marketplace-images",
+    "description": "Audit Virtual Machines based on marketplace images. createOption value is used when you are using an image to create the virtual machine.",
+    "metadata": {
+      "category": "Compute",
+      "version": "1.0.0"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Compute/virtualMachines"
+          },
+          {
+            "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.createOption",
+            "equals": "FromImage"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/Compute/audit-vms-based-on-marketplace-images/azurepolicy.parameters.json
+++ b/Policies/Compute/audit-vms-based-on-marketplace-images/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Deny",
+      "Disabled"
+    ],
+    "defaultValue": "Audit"
+  }
+}

--- a/Policies/Compute/audit-vms-based-on-marketplace-images/azurepolicy.rules.json
+++ b/Policies/Compute/audit-vms-based-on-marketplace-images/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Compute/virtualMachines"
+      },
+      {
+        "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.createOption",
+        "equals": "FromImage"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/Compute/audit-vmsss-based-on-marketplace-images/azurepolicy.json
+++ b/Policies/Compute/audit-vmsss-based-on-marketplace-images/azurepolicy.json
@@ -1,0 +1,45 @@
+{
+  "name": "b6020716-02c1-4569-b0af-c30bd1e9cb3d",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "audit-vmsss-based-on-marketplace-images",
+    "description": "Audit Virtual Machine Scale Sets based on marketplace images. createOption value is used when you are using an image to create the virtual machine.",
+    "metadata": {
+      "category": "Compute",
+      "version": "1.0.0"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Compute/VirtualMachineScaleSets"
+          },
+          {
+            "field": "Microsoft.Compute/VirtualMachineScaleSets/osDisk.createOption",
+            "equals": "FromImage"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/Compute/audit-vmsss-based-on-marketplace-images/azurepolicy.parameters.json
+++ b/Policies/Compute/audit-vmsss-based-on-marketplace-images/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Deny",
+      "Disabled"
+    ],
+    "defaultValue": "Audit"
+  }
+}

--- a/Policies/Compute/audit-vmsss-based-on-marketplace-images/azurepolicy.rules.json
+++ b/Policies/Compute/audit-vmsss-based-on-marketplace-images/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Compute/VirtualMachineScaleSets"
+      },
+      {
+        "field": "Microsoft.Compute/VirtualMachineScaleSets/osDisk.createOption",
+        "equals": "FromImage"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}


### PR DESCRIPTION
Audit Virtual Machines+VMSS based on marketplace images. createOption value is used when you are using an image to create the virtual machine.
The policy checks if VMs or VM Scale Sets based on Microsoft operation system is using BYOL for Azure Hybrid Benefit.