### PR TITLE
deploy-diagnostic-setting-for-activity-log-storage-account

### DIFF
--- a/Policies/Monitoring/deploy-diagnostic-setting-for-activity-log-storage-account/azurepolicy.json
+++ b/Policies/Monitoring/deploy-diagnostic-setting-for-activity-log-storage-account/azurepolicy.json
@@ -1,0 +1,133 @@
+﻿
+{    
+    "mode": "All",
+    "displayName": "Deploy Diagnostic Settings for Activity Log to storage account",
+    "description": "Deploys the diagnostic settings for Activity Log to stream to a storage account when any Subscription which is missing this diagnostic settings is created or updated.",
+    "parameters": {
+        "effect": {
+            "type": "string",
+            "metadata": {
+                "displayName": "Effect",
+                "description": "Enable or disable the execution of the policy"
+            },
+            "allowedValues": [
+            "DeployIfNotExists",
+            "Disabled"
+            ],
+            "defaultValue": "DeployIfNotExists"
+        },
+        "logsEnabled": {
+            "type": "String",
+            "metadata": {
+            "displayName": "Enable logs",
+            "description": "Whether to enable logs stream to the storage account - True or False"
+            },
+            "allowedValues": [
+            "True",
+            "False"
+            ],
+            "defaultValue": "True"
+        },
+        "storageAccountId": {
+            "type": "String",
+            "metadata": {
+                "displayName": "Storage Account ResourceId",
+                "description": "The resource ID of the storage account to which you would like to send Diagnostic Logs"
+            }
+        },
+        "profileName": {
+            "type": "String",
+            "metadata": {
+                "displayName": "Diagnostic Setting Profile Name",
+                "description": "Provide the name of the diagnistic setting profile to validate."
+            }
+        }
+    },
+    "policyRule": {
+        "if": {
+            "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.Resources/subscriptions"
+                }
+            ]
+        },
+        "then": {
+            "effect": "[parameters('effect')]",
+            "details": {
+                "type": "Microsoft.Insights/diagnosticSettings",
+                "deploymentScope": "Subscription",
+                "existenceScope": "Subscription",
+                "name": "[parameters('profileName')]",
+                "existenceCondition": {
+                    "allOf": [
+                        {
+                            "count": {
+                                "field": "Microsoft.Insights/diagnosticSettings/logs[*]",
+                                "where": {
+                                    "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                    "equals": "[parameters('logsEnabled')]"
+                                }
+                            },
+                            "equals": 1
+                        },
+                        {
+                            "field": "Microsoft.Insights/diagnosticSettings/storageAccountId",
+                            "equals": "[parameters('storageAccountId')]"
+                        }
+                    ]
+                },
+                "roleDefinitionIds": [
+                    "/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293"
+                ],
+                "deployment": {
+                    "location": "eastus",
+                    "properties": {
+                        "mode": "incremental",
+                        "template": {
+                            "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+                            "contentVersion": "1.0.0.0",
+                            "parameters": {
+                                "storageAccountId": {
+                                    "type": "string"
+                                },
+                                "profileName": {
+                                    "type": "string"
+                                }
+                            },
+                            "variables": {},
+                            "resources": [
+                                {
+                                    "type": "Microsoft.Insights/diagnosticSettings",
+                                    "apiVersion": "2021-05-01-preview",
+                                    "name": "[parameters('profileName')]",
+                                    "location": "Global",
+                                    "properties": {
+                                        "storageAccountId": "[parameters('storageAccountId')]",
+                                        "logs": [
+                                            {
+                                                "category": "Administrative",
+                                                "enabled": true
+                                            }
+                                        ],
+                                        "metrics": []
+                                    }
+                                }
+                            ],
+                            "outputs": {}
+                        },
+                        "parameters": {
+                            "storageAccountId": {
+                                "value": "[parameters('storageAccountId')]"
+                            },
+                            "profileName": {
+                                "value": "[parameters('profileName')]"
+                            }
+
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Policies/Monitoring/deploy-diagnostic-setting-for-activity-log-storage-account/azurepolicy.parameters.json
+++ b/Policies/Monitoring/deploy-diagnostic-setting-for-activity-log-storage-account/azurepolicy.parameters.json
@@ -1,0 +1,40 @@
+{
+    "effect": {
+        "type": "string",
+        "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+        "DeployIfNotExists",
+        "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists"
+    },
+    "logsEnabled": {
+        "type": "String",
+        "metadata": {
+        "displayName": "Enable logs",
+        "description": "Whether to enable logs stream to the storage account - True or False"
+        },
+        "allowedValues": [
+        "True",
+        "False"
+        ],
+        "defaultValue": "True"
+    },
+    "storageAccountId": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Storage Account ResourceId",
+            "description": "The resource ID of the storage account to which you would like to send Diagnostic Logs"
+        }
+    },
+    "profileName": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Diagnostic Setting Profile Name",
+            "description": "Provide the name of the diagnistic setting profile to validate."
+        }
+    }
+}

--- a/Policies/Monitoring/deploy-diagnostic-setting-for-activity-log-storage-account/azurepolicy.rules.json
+++ b/Policies/Monitoring/deploy-diagnostic-setting-for-activity-log-storage-account/azurepolicy.rules.json
@@ -1,0 +1,87 @@
+{
+    "if": {
+        "allOf": [
+            {
+                "field": "type",
+                "equals": "Microsoft.Resources/subscriptions"
+            }
+        ]
+    },
+    "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+            "type": "Microsoft.Insights/diagnosticSettings",
+            "deploymentScope": "Subscription",
+            "existenceScope": "Subscription",
+            "name": "[parameters('profileName')]",
+            "existenceCondition": {
+                "allOf": [
+                    {
+                        "count": {
+                            "field": "Microsoft.Insights/diagnosticSettings/logs[*]",
+                            "where": {
+                                "field": "Microsoft.Insights/diagnosticSettings/logs[*].enabled",
+                                "equals": "[parameters('logsEnabled')]"
+                            }
+                        },
+                        "equals": 1
+                    },
+                    {
+                        "field": "Microsoft.Insights/diagnosticSettings/storageAccountId",
+                        "equals": "[parameters('storageAccountId')]"
+                    }
+                ]
+            },
+            "roleDefinitionIds": [
+                "/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293"
+            ],
+            "deployment": {
+                "location": "eastus",
+                "properties": {
+                    "mode": "incremental",
+                    "template": {
+                        "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+                        "contentVersion": "1.0.0.0",
+                        "parameters": {
+                            "storageAccountId": {
+                                "type": "string"
+                            },
+                            "profileName": {
+                                "type": "string"
+                            }
+                        },
+                        "variables": {},
+                        "resources": [
+                            {
+                                "type": "Microsoft.Insights/diagnosticSettings",
+                                "apiVersion": "2021-05-01-preview",
+                                "name": "[parameters('profileName')]",
+                                "location": "Global",
+                                "properties": {
+                                    "storageAccountId": "[parameters('storageAccountId')]",
+                                    "logs": [
+                                        {
+                                            "category": "Administrative",
+                                            "enabled": true
+                                        }
+                                    ],
+                                    "metrics": []
+                                }
+                            }
+                        ],
+                        "outputs": {}
+                    },
+                    "parameters": {
+                        "storageAccountId": {
+                            "value": "[parameters('storageAccountId')]"
+                        },
+                        "profileName": {
+                            "value": "[parameters('profileName')]"
+                        }
+
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added Policy definition 'deploy-diagnostic-setting-for-activity-log-storage-account' to complement existing policies that target Log Analytics and Event Hub.