### PR TITLE
Permit Cognitive Service Kinds and OpenAI Models

### DIFF
--- a/Policies/CognitiveServices/allowed-cognitive-types/azurepolicy.json
+++ b/Policies/CognitiveServices/allowed-cognitive-types/azurepolicy.json
@@ -1,0 +1,88 @@
+{
+    "properties": {
+        "displayName": "Only approved types Cognitive Services resources",
+        "policyType": "Custom",
+        "mode": "Indexed",
+        "description": "This policy permits only certain types of Cognitive Services resources to be deployed.",
+        "metadata": {
+            "category": "Cognitive Services"
+        },
+        "parameters": {
+            "effect": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "Enable or disable the execution of the policy"
+                },
+                "allowedValues": [
+                    "Audit",
+                    "Deny",
+                    "Disabled"
+                ],
+                "defaultValue": "Audit"
+                },
+            "listOfAllowedKind": {
+            "type": "Array",
+            "metadata": {
+                "description": "The list of Cognitive Services resources that can be deployed.",
+                "displayName": "Allowed Cognitive Services resources"
+            },
+            "allowedValues": [
+                "Academic",
+                "AnomalyDetector",
+                "Bing.Autosuggest",
+                "Bing.Autosuggest.v7",
+                "Bing.CustomSearch",
+                "Bing.Search",
+                "Bing.Search.v7",
+                "Bing.Speech",
+                "Bing.SpellCheck",
+                "Bing.SpellCheck.v7",
+                "CognitiveServices",
+                "ComputerVision",
+                "ContentModerator",
+                "CustomSpeech",
+                "CustomVision.Prediction",
+                "CustomVision.Training",
+                "Emotion",
+                "Face",
+                "FormRecognizer",
+                "ImmersiveReader",
+                "LUIS",
+                "LUIS.Authoring",
+                "MetricsAdvisor",
+                "OpenAI",
+                "Personalizer",
+                "QnAMaker",
+                "Recommendations",
+                "SpeakerRecognition",
+                "Speech",
+                "SpeechServices",
+                "SpeechTranslation",
+                "TextAnalytics",
+                "TextTranslation",
+                "WebLM"
+            ]
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.CognitiveServices/accounts"
+                },
+                {
+                    "not": {
+                        "field": "kind",
+                        "in": "[parameters('listOfAllowedKind')]"
+                    }
+                }
+                ]
+            },
+                "then": {
+                "effect": "[parameters('effect')]" 
+            }
+        }
+    }
+}

--- a/Policies/CognitiveServices/allowed-cognitive-types/azurepolicy.json
+++ b/Policies/CognitiveServices/allowed-cognitive-types/azurepolicy.json
@@ -1,10 +1,14 @@
 {
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "apiVersion": "2021-06-01",
+    "name": "c4f50e79-ce44-4b76-b4e1-58330703e842",
     "properties": {
         "displayName": "Only approved types Cognitive Services resources",
         "policyType": "Custom",
-        "mode": "Indexed",
+        "mode": "All",
         "description": "This policy permits only certain types of Cognitive Services resources to be deployed.",
         "metadata": {
+            "version": "1.0.0",
             "category": "Cognitive Services"
         },
         "parameters": {
@@ -22,47 +26,47 @@
                 "defaultValue": "Audit"
                 },
             "listOfAllowedKind": {
-            "type": "Array",
-            "metadata": {
-                "description": "The list of Cognitive Services resources that can be deployed.",
-                "displayName": "Allowed Cognitive Services resources"
-            },
-            "allowedValues": [
-                "Academic",
-                "AnomalyDetector",
-                "Bing.Autosuggest",
-                "Bing.Autosuggest.v7",
-                "Bing.CustomSearch",
-                "Bing.Search",
-                "Bing.Search.v7",
-                "Bing.Speech",
-                "Bing.SpellCheck",
-                "Bing.SpellCheck.v7",
-                "CognitiveServices",
-                "ComputerVision",
-                "ContentModerator",
-                "CustomSpeech",
-                "CustomVision.Prediction",
-                "CustomVision.Training",
-                "Emotion",
-                "Face",
-                "FormRecognizer",
-                "ImmersiveReader",
-                "LUIS",
-                "LUIS.Authoring",
-                "MetricsAdvisor",
-                "OpenAI",
-                "Personalizer",
-                "QnAMaker",
-                "Recommendations",
-                "SpeakerRecognition",
-                "Speech",
-                "SpeechServices",
-                "SpeechTranslation",
-                "TextAnalytics",
-                "TextTranslation",
-                "WebLM"
-            ]
+                "type": "Array",
+                "metadata": {
+                    "description": "The list of Cognitive Services resources that can be deployed.",
+                    "displayName": "Allowed Cognitive Services resources"
+                },
+                "allowedValues": [
+                    "Academic",
+                    "AnomalyDetector",
+                    "Bing.Autosuggest",
+                    "Bing.Autosuggest.v7",
+                    "Bing.CustomSearch",
+                    "Bing.Search",
+                    "Bing.Search.v7",
+                    "Bing.Speech",
+                    "Bing.SpellCheck",
+                    "Bing.SpellCheck.v7",
+                    "CognitiveServices",
+                    "ComputerVision",
+                    "ContentModerator",
+                    "CustomSpeech",
+                    "CustomVision.Prediction",
+                    "CustomVision.Training",
+                    "Emotion",
+                    "Face",
+                    "FormRecognizer",
+                    "ImmersiveReader",
+                    "LUIS",
+                    "LUIS.Authoring",
+                    "MetricsAdvisor",
+                    "OpenAI",
+                    "Personalizer",
+                    "QnAMaker",
+                    "Recommendations",
+                    "SpeakerRecognition",
+                    "Speech",
+                    "SpeechServices",
+                    "SpeechTranslation",
+                    "TextAnalytics",
+                    "TextTranslation",
+                    "WebLM"
+                ]
             }
         },
         "policyRule": {

--- a/Policies/CognitiveServices/allowed-cognitive-types/azurepolicy.parameters.json
+++ b/Policies/CognitiveServices/allowed-cognitive-types/azurepolicy.parameters.json
@@ -1,0 +1,58 @@
+{
+    "effect": {
+    "type": "String",
+    "metadata": {
+        "displayName": "Effect",
+        "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+        "Audit",
+        "Deny",
+        "Disabled"
+    ],
+    "defaultValue": "Audit"
+    },
+"listOfAllowedKind": {
+"type": "Array",
+"metadata": {
+    "description": "The list of Cognitive Services resources that can be deployed.",
+    "displayName": "Allowed Cognitive Services resources"
+},
+"allowedValues": [
+    "Academic",
+    "AnomalyDetector",
+    "Bing.Autosuggest",
+    "Bing.Autosuggest.v7",
+    "Bing.CustomSearch",
+    "Bing.Search",
+    "Bing.Search.v7",
+    "Bing.Speech",
+    "Bing.SpellCheck",
+    "Bing.SpellCheck.v7",
+    "CognitiveServices",
+    "ComputerVision",
+    "ContentModerator",
+    "CustomSpeech",
+    "CustomVision.Prediction",
+    "CustomVision.Training",
+    "Emotion",
+    "Face",
+    "FormRecognizer",
+    "ImmersiveReader",
+    "LUIS",
+    "LUIS.Authoring",
+    "MetricsAdvisor",
+    "OpenAI",
+    "Personalizer",
+    "QnAMaker",
+    "Recommendations",
+    "SpeakerRecognition",
+    "Speech",
+    "SpeechServices",
+    "SpeechTranslation",
+    "TextAnalytics",
+    "TextTranslation",
+    "WebLM"
+]
+}
+}

--- a/Policies/CognitiveServices/allowed-cognitive-types/azurepolicy.rules.json
+++ b/Policies/CognitiveServices/allowed-cognitive-types/azurepolicy.rules.json
@@ -1,0 +1,19 @@
+{
+    "if": {
+        "allOf": [
+        {
+            "field": "type",
+            "equals": "Microsoft.CognitiveServices/accounts"
+        },
+        {
+            "not": {
+                "field": "kind",
+                "in": "[parameters('listOfAllowedKind')]"
+            }
+        }
+        ]
+    },
+        "then": {
+        "effect": "[parameters('effect')]" 
+    }
+}

--- a/Policies/CognitiveServices/allowed-openai-models/azurepolicy.json
+++ b/Policies/CognitiveServices/allowed-openai-models/azurepolicy.json
@@ -1,0 +1,90 @@
+{
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "apiVersion": "2021-06-01",
+    "name": "014bf9e4-f49f-4aed-a9b0-c56399f90784",
+    "properties": {
+        "displayName": "Permit only approved OpenAI models",
+        "policyType": "Custom",
+        "mode": "All",
+        "description": "This policy permits only certain types of OpenAI models to be deployed",
+        "metadata": {
+            "version": "1.0.0",
+            "category": "Cognitive Services"
+        },
+        "parameters": {
+            "effect": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "Enable or disable the execution of the policy"
+                },
+                "allowedValues": [
+                    "Audit",
+                    "Deny",
+                    "Disabled"
+                ],
+                "defaultValue": "Audit"
+                },
+            "listOfAllowedModels": {
+                "type": "Array",
+                "metadata": {
+                    "description": "The list of Open AI models that can be deployed.",
+                    "displayName": "Allowed Open AI models"
+                },
+                "allowedValues": [
+                    "gpt-4",
+                    "gpt-4-32k",
+                    "text-davinci-003",
+                    "text-curie-001",
+                    "code-davinci-002",
+                    "code-cushman-001",
+                    "text-similarity-ada-001",
+                    "text-similarity-babbage-001",
+                    "text-similarity-curie-001",
+                    "text-similarity-davinci-001",
+                    "text-search-ada-doc-001",
+                    "text-search-ada-query-001",
+                    "text-search-babbage-doc-001",
+                    "text-search-babbage-query-001",
+                    "text-search-curie-doc-001",
+                    "text-search-curie-query-001",
+                    "text-search-davinci-doc-001",
+                    "text-search-davinci-query-001",
+                    "code-search-ada-code-001",
+                    "code-search-ada-text-001",
+                    "code-search-babbage-code-001",
+                    "code-search-babbage-text-001",
+                    "gpt-35-turbo (version 0301)",
+                    "text-ada-001",
+                    "text-babbage-001",
+                    "text-davinci-001",
+                    "text-davinci-002",
+                    "text-embedding-ada-002"
+                ]
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                {
+                    "field": "type",
+                    "equals": "Microsoft.CognitiveServices/accounts/deployments"
+                },
+                {
+                    "field": "Microsoft.CognitiveServices/accounts/deployments/model.format",
+                    "equals": "OpenAI"
+                },
+                {
+                    "not": {
+                        "field": "Microsoft.CognitiveServices/accounts/deployments/model.name",
+                        "in": "[parameters('listOfAllowedModels')]"
+                    }
+                }
+                ]
+            },
+                "then": {
+                "effect": "[parameters('effect')]" 
+            }
+        }
+    }
+}

--- a/Policies/CognitiveServices/allowed-openai-models/azurepolicy.parameters.json
+++ b/Policies/CognitiveServices/allowed-openai-models/azurepolicy.parameters.json
@@ -1,0 +1,52 @@
+{
+    "effect": {
+    "type": "String",
+    "metadata": {
+        "displayName": "Effect",
+        "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+        "Audit",
+        "Deny",
+        "Disabled"
+    ],
+    "defaultValue": "Audit"
+    },
+    "listOfAllowedModels": {
+        "type": "Array",
+        "metadata": {
+            "description": "The list of Open AI models that can be deployed.",
+            "displayName": "Allowed Open AI models"
+        },
+        "allowedValues": [
+            "gpt-4",
+            "gpt-4-32k",
+            "text-davinci-003",
+            "text-curie-001",
+            "code-davinci-002",
+            "code-cushman-001",
+            "text-similarity-ada-001",
+            "text-similarity-babbage-001",
+            "text-similarity-curie-001",
+            "text-similarity-davinci-001",
+            "text-search-ada-doc-001",
+            "text-search-ada-query-001",
+            "text-search-babbage-doc-001",
+            "text-search-babbage-query-001",
+            "text-search-curie-doc-001",
+            "text-search-curie-query-001",
+            "text-search-davinci-doc-001",
+            "text-search-davinci-query-001",
+            "code-search-ada-code-001",
+            "code-search-ada-text-001",
+            "code-search-babbage-code-001",
+            "code-search-babbage-text-001",
+            "gpt-35-turbo (version 0301)",
+            "text-ada-001",
+            "text-babbage-001",
+            "text-davinci-001",
+            "text-davinci-002",
+            "text-embedding-ada-002"
+        ]
+    }
+}

--- a/Policies/CognitiveServices/allowed-openai-models/azurepolicy.rules.json
+++ b/Policies/CognitiveServices/allowed-openai-models/azurepolicy.rules.json
@@ -1,0 +1,23 @@
+{
+    "if": {
+        "allOf": [
+        {
+            "field": "type",
+            "equals": "Microsoft.CognitiveServices/accounts/deployments"
+        },
+        {
+            "field": "Microsoft.CognitiveServices/accounts/deployments/model.format",
+            "equals": "OpenAI"
+        },
+        {
+            "not": {
+                "field": "Microsoft.CognitiveServices/accounts/deployments/model.name",
+                "in": "[parameters('listOfAllowedModels')]"
+            }
+        }
+        ]
+    },
+        "then": {
+        "effect": "[parameters('effect')]" 
+    }
+}


### PR DESCRIPTION
This PR adds the following policies:

Only approved kinds Cognitive Services resources
Permit only approved OpenAI models