### PR TITLE
Add deny-bastion-shared-links Policy definition

### DIFF
--- a/Policies/Bastion/deny-shared-links/azurepolicy.json
+++ b/Policies/Bastion/deny-shared-links/azurepolicy.json
@@ -1,0 +1,47 @@
+﻿{
+    "name": "deny-bastion-shared-links",
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "properties": {
+        "displayName": "Deny Bastion Shared Links",
+        "description": "The Bastion Shareable Link feature lets users connect to a target resource (virtual machine or virtual machine scale set) using Azure Bastion without accessing the Azure portal.",
+        "mode": "All",
+        "policyType": "Custom",
+        "metadata": {
+            "version": "1.0.0",
+            "category": "Network"
+        },
+        "parameters": {
+            "effect": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "Enable or disable the execution of the policy"
+                },
+                "allowedValues": [
+                    "deny",
+                    "disabled"
+                ],
+                "defaultValue": "deny"
+            }
+        },
+        "policyRule": {
+            "if": {
+            "allOf": [
+                {
+                    "equals": "microsoft.network/bastionhosts",
+                    "field": "type"
+                },
+                {
+                    "not": {
+                        "field": "Microsoft.Network/bastionHosts/enableShareableLink",
+                        "equals": "False"
+                    }
+                }
+            ]
+            },
+            "then": {
+                "effect": "[parameters('effect')]"
+            }
+        }
+    }
+}

--- a/Policies/Bastion/deny-shared-links/azurepolicy.parameters.json
+++ b/Policies/Bastion/deny-shared-links/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+﻿{
+    "effect": {
+        "type": "String",
+        "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+            "deny",
+            "disabled"
+        ],
+        "defaultValue": "deny"
+    }
+}

--- a/Policies/Bastion/deny-shared-links/azurepolicy.rules.json
+++ b/Policies/Bastion/deny-shared-links/azurepolicy.rules.json
@@ -1,0 +1,19 @@
+﻿{
+    "if": {
+        "allOf": [
+            {
+                "equals": "microsoft.network/bastionhosts",
+                "field": "type"
+            },
+            {
+                "not": {
+                    "field": "Microsoft.Network/bastionHosts/enableShareableLink",
+                    "equals": "False"
+                }
+            }
+        ]
+    },
+    "then": {
+        "effect": "[parameters('effect')]"
+    }
+}


### PR DESCRIPTION
The Bastion Shareable Link feature lets users connect to a target resource (virtual machine or virtual machine scale set) using Azure Bastion without accessing the Azure portal.

If you don't want to expose this feature, this policy will prevent enabling the setting.