### PR TITLE
Restrict cloud shell storage account creation

### DIFF
--- a/Policies/Storage/Restrict cloud shell storage account creation/azurepolicy.json
+++ b/Policies/Storage/Restrict cloud shell storage account creation/azurepolicy.json
@@ -1,0 +1,45 @@
+{
+  "name": "85e1cbb5-1687-4d33-abda-f02b8395b36d",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Restrict cloud shell storage account creation",
+    "description": "Storage accounts that you create in Cloud Shell are tagged with ms-resource-usage:azure-cloud-shell. If you want to disallow users from creating storage accounts in Cloud Shell, create an Azure resource policy for tags that is triggered by this specific tag. https://learn.microsoft.com/en-us/azure/cloud-shell/persisting-shell-storage#restrict-resource-creation-with-an-azure-resource-policy",
+    "metadata": {
+      "category": "Tags",
+      "version": "1.0.0"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "Deny",
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Deny"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Storage/storageAccounts"
+          },
+          {
+            "field": "tags['ms-resource-usage']",
+            "equals": "azure-cloud-shell"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/Storage/Restrict cloud shell storage account creation/azurepolicy.parameters.json
+++ b/Policies/Storage/Restrict cloud shell storage account creation/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "Deny",
+      "Audit",
+      "Disabled"
+    ],
+    "defaultValue": "Deny"
+  }
+}

--- a/Policies/Storage/Restrict cloud shell storage account creation/azurepolicy.rules.json
+++ b/Policies/Storage/Restrict cloud shell storage account creation/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Storage/storageAccounts"
+      },
+      {
+        "field": "tags['ms-resource-usage']",
+        "equals": "azure-cloud-shell"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}


### PR DESCRIPTION
Storage accounts that you create in Cloud Shell are tagged with ms-resource-usage:azure-cloud-shell. If you want to disallow users from creating storage accounts in Cloud Shell - which you have several good security reasons for - create an Azure resource policy for tags that is triggered by this specific tag. https://learn.microsoft.com/en-us/azure/cloud-shell/persisting-shell-storage#restrict-resource-creation-with-an-azure-resource-policy
