### PR TITLE
Output script to create folder to put files in

### DIFF
--- a/Scripts/Out-FormattedPolicyDefinitionToThreeFiles.ps1
+++ b/Scripts/Out-FormattedPolicyDefinitionToThreeFiles.ps1
@@ -48,10 +48,12 @@ $newDefinition = Format-PolicyDefinition -fileName $fileName -category $category
 if ($null -ne $newDefinition) {
     $newDefinitionJson = $newDefinition | ConvertTo-Json -Depth 100
 
+    $newDisplayName = $newDefinition.properties.displayName
+
     $file = Get-Item -Path $fileName
     $folderPath = $file.DirectoryName
     if (!([string]::IsNullOrEmpty($outputDirectory))) {
-        $folderPath = $outputDirectory
+        $folderPath = ($outputDirectory + "\" + $newDisplayName)
         #create the directory if it doesn't exist
         if (!(Test-Path $folderPath)) {
             $null = (New-Item -ItemType Directory -Path $folderPath -Force -InformationAction SilentlyContinue)


### PR DESCRIPTION
Ensure that the created files are put in a folder that is related to the policy displayName. This is especially nice when you run the script multiple times on different policies, so it does not overwrite policies plus it makes it easier to upload files as they are already in a folder