### PR TITLE
adding new azure policy for Azure Disk - Disk state

### DIFF
--- a/Policies/Compute/allowed-disk-diskstates/azurepolicy.json
+++ b/Policies/Compute/allowed-disk-diskstates/azurepolicy.json
@@ -1,0 +1,58 @@
+{
+    "name": "d1379bd4-3422-453f-896a-b7ae8333aa7f",
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "properties": {
+        "displayName": "Allowed Disk states for Azure Disks",
+        "mode": "Indexed",
+        "description": "This policy audits or blocks certain disk states for Azure Disks. https://learn.microsoft.com/en-us/rest/api/compute/disks/get?tabs=HTTP#diskstate",
+        "metaData": {
+            "category": "Compute",
+            "version": "1.0.0"
+        },
+        "parameters": {
+            "effect": {
+                "type": "string",
+                "metaData": {
+                    "displayName": "Policy effect",
+                    "description": "Audit or deny the execution of the Policy"
+                },
+                "allowedValues": [
+                    "Audit",
+                    "Deny",
+                    "Disabled"
+                ],
+                "defaultValue": "Audit"
+            },
+            "disallowedState": {
+                "type": "array",
+                "metaData": {
+                    "displayName": "Disallowed disk state",
+                    "description": "Controls what disk states are disallowed. Described at https://learn.microsoft.com/en-us/rest/api/compute/disks/get?tabs=HTTP#diskstate"
+                },
+                "allowedValues": [
+                    "ActiveSAS",
+                    "ActiveSASFrozen",
+                    "ActiveUpload",
+                    "Attached",
+                    "Frozen",
+                    "ReadyToUpload",
+                    "Reserved",
+                    "Unattached"
+                ],
+                "defaultValue": [
+                    "ActiveSAS",
+                    "ActiveSASFrozen"
+                ]
+            }
+        },
+        "policyRule": {
+            "if": {
+                "field": "Microsoft.Compute/disks/diskState",
+                "in": "[parameters('disallowedState')]"
+            },
+            "then": {
+                "effect": "[parameters('effect')]"
+            }
+        }
+    }
+}

--- a/Policies/Compute/allowed-disk-diskstates/azurepolicy.parameters.json
+++ b/Policies/Compute/allowed-disk-diskstates/azurepolicy.parameters.json
@@ -1,0 +1,36 @@
+{
+    "effect": {
+        "type": "string",
+        "metaData": {
+            "displayName": "Policy effect",
+            "description": "Audit or deny the execution of the Policy"
+        },
+        "allowedValues": [
+            "Audit",
+            "Deny",
+            "Disabled"
+        ],
+        "defaultValue": "Audit"
+    },
+    "disallowedState": {
+        "type": "array",
+        "metaData": {
+            "displayName": "Disallowed disk state",
+            "description": "Controls what disk states are disallowed. Described at https://learn.microsoft.com/en-us/rest/api/compute/disks/get?tabs=HTTP#diskstate"
+        },
+        "allowedValues": [
+            "ActiveSAS",
+            "ActiveSASFrozen",
+            "ActiveUpload",
+            "Attached",
+            "Frozen",
+            "ReadyToUpload",
+            "Reserved",
+            "Unattached"
+        ],
+        "defaultValue": [
+            "ActiveSAS",
+            "ActiveSASFrozen"
+        ]
+    }
+}

--- a/Policies/Compute/allowed-disk-diskstates/azurepolicy.rules.json
+++ b/Policies/Compute/allowed-disk-diskstates/azurepolicy.rules.json
@@ -1,0 +1,9 @@
+{
+    "if": {
+        "field": "Microsoft.Compute/disks/diskState",
+        "in": "[parameters('disallowedState')]"
+    },
+    "then": {
+        "effect": "[parameters('effect')]"
+    }
+}


### PR DESCRIPTION
New Azure policy to control the disk state for Azure Disks.
Disallowing the diskState to be set to, for example ActiveSAS or ActiveSASFrozen will block the possibility of exporting an Azure disk using SAS tokens.