### PR TITLE
adding new azure policy for Azure Snapshots - Diskstate

### DIFF
--- a/Policies/Compute/allowed-snapshots-diskstates/azurepolicy.json
+++ b/Policies/Compute/allowed-snapshots-diskstates/azurepolicy.json
@@ -1,0 +1,53 @@
+{
+    "displayName": "Allowed Disk states for Snapshots",
+    "mode": "Indexed",
+    "description": "This policy audits or blocks certain disk states for Azure Snapshots. https://learn.microsoft.com/en-us/rest/api/compute/snapshots/get?tabs=HTTP#diskstate",
+    "metaData": {
+        "category": "Compute"
+    },
+    "parameters": {
+        "effect": {
+            "type": "string",
+            "metaData": {
+                "displayName": "Effects",
+                "description": "Selected effect for the Policy"
+            },
+            "allowedValues": [
+                "Audit",
+                "Deny",
+                "Disabled"
+            ],
+            "defaultValue": "Audit"
+        },
+        "disallowedState": {
+            "type": "array",
+            "metaData": {
+                "displayName": "Disallowed disk state",
+                "description": "Controls what disk states are disallowed. Described at https://learn.microsoft.com/en-us/rest/api/compute/snapshots/get?tabs=HTTP#diskstate"
+            },
+            "allowedValues": [
+                "ActiveSAS",
+                "ActiveSASFrozen",
+                "ActiveUpload",
+                "Attached",
+                "Frozen",
+                "ReadyToUpload",
+                "Reserved",
+                "Unattached"
+            ],
+            "defaultValue": [
+                "ActiveSAS",
+                "ActiveSASFrozen"
+            ]
+        }
+    },
+    "policyRule": {
+        "if": {
+            "field": "Microsoft.Compute/snapshots/diskState",
+            "in": "[parameters('disallowedState')]"
+        },
+        "then": {
+            "effect": "[parameters('effect')]"
+        }
+    }
+}

--- a/Policies/Compute/allowed-snapshots-diskstates/azurepolicy.json
+++ b/Policies/Compute/allowed-snapshots-diskstates/azurepolicy.json
@@ -1,53 +1,57 @@
 {
-    "displayName": "Allowed Disk states for Snapshots",
-    "mode": "Indexed",
-    "description": "This policy audits or blocks certain disk states for Azure Snapshots. https://learn.microsoft.com/en-us/rest/api/compute/snapshots/get?tabs=HTTP#diskstate",
-    "metaData": {
-        "category": "Compute"
-    },
-    "parameters": {
-        "effect": {
-            "type": "string",
-            "metaData": {
-                "displayName": "Effects",
-                "description": "Selected effect for the Policy"
-            },
-            "allowedValues": [
-                "Audit",
-                "Deny",
-                "Disabled"
-            ],
-            "defaultValue": "Audit"
+    "name": "1288f298-54e0-441c-a1d4-8b35006679fe",
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "properties": {
+        "displayName": "Allowed Disk states for Snapshots",
+        "mode": "Indexed",
+        "description": "This policy audits or blocks certain disk states for Azure Snapshots. https://learn.microsoft.com/en-us/rest/api/compute/snapshots/get?tabs=HTTP#diskstate",
+        "metaData": {
+            "category": "Compute"
         },
-        "disallowedState": {
-            "type": "array",
-            "metaData": {
-                "displayName": "Disallowed disk state",
-                "description": "Controls what disk states are disallowed. Described at https://learn.microsoft.com/en-us/rest/api/compute/snapshots/get?tabs=HTTP#diskstate"
+        "parameters": {
+            "effect": {
+                "type": "string",
+                "metaData": {
+                    "displayName": "Effects",
+                    "description": "Selected effect for the Policy"
+                },
+                "allowedValues": [
+                    "Audit",
+                    "Deny",
+                    "Disabled"
+                ],
+                "defaultValue": "Audit"
             },
-            "allowedValues": [
-                "ActiveSAS",
-                "ActiveSASFrozen",
-                "ActiveUpload",
-                "Attached",
-                "Frozen",
-                "ReadyToUpload",
-                "Reserved",
-                "Unattached"
-            ],
-            "defaultValue": [
-                "ActiveSAS",
-                "ActiveSASFrozen"
-            ]
-        }
-    },
-    "policyRule": {
-        "if": {
-            "field": "Microsoft.Compute/snapshots/diskState",
-            "in": "[parameters('disallowedState')]"
+            "disallowedState": {
+                "type": "array",
+                "metaData": {
+                    "displayName": "Disallowed disk state",
+                    "description": "Controls what disk states are disallowed. Described at https://learn.microsoft.com/en-us/rest/api/compute/snapshots/get?tabs=HTTP#diskstate"
+                },
+                "allowedValues": [
+                    "ActiveSAS",
+                    "ActiveSASFrozen",
+                    "ActiveUpload",
+                    "Attached",
+                    "Frozen",
+                    "ReadyToUpload",
+                    "Reserved",
+                    "Unattached"
+                ],
+                "defaultValue": [
+                    "ActiveSAS",
+                    "ActiveSASFrozen"
+                ]
+            }
         },
-        "then": {
-            "effect": "[parameters('effect')]"
+        "policyRule": {
+            "if": {
+                "field": "Microsoft.Compute/snapshots/diskState",
+                "in": "[parameters('disallowedState')]"
+            },
+            "then": {
+                "effect": "[parameters('effect')]"
+            }
         }
     }
 }

--- a/Policies/Compute/allowed-snapshots-diskstates/azurepolicy.parameters.json
+++ b/Policies/Compute/allowed-snapshots-diskstates/azurepolicy.parameters.json
@@ -1,0 +1,36 @@
+{
+    "effect": {
+        "type": "string",
+        "metaData": {
+            "displayName": "Effects",
+            "description": "Selected effect for the Policy"
+        },
+        "allowedValues": [
+            "Audit",
+            "Deny",
+            "Disabled"
+        ],
+        "defaultValue": "Audit"
+    },
+    "disallowedState": {
+        "type": "array",
+        "metaData": {
+            "displayName": "Disallowed disk state",
+            "description": "Controls what disk states are disallowed. Described at https://learn.microsoft.com/en-us/rest/api/compute/snapshots/get?tabs=HTTP#diskstate"
+        },
+        "allowedValues": [
+            "ActiveSAS",
+            "ActiveSASFrozen",
+            "ActiveUpload",
+            "Attached",
+            "Frozen",
+            "ReadyToUpload",
+            "Reserved",
+            "Unattached"
+        ],
+        "defaultValue": [
+            "ActiveSAS",
+            "ActiveSASFrozen"
+        ]
+    }
+}

--- a/Policies/Compute/allowed-snapshots-diskstates/azurepolicy.rules.json
+++ b/Policies/Compute/allowed-snapshots-diskstates/azurepolicy.rules.json
@@ -1,0 +1,9 @@
+{
+    "if": {
+        "field": "Microsoft.Compute/snapshots/diskState",
+        "in": "[parameters('disallowedState')]"
+    },
+    "then": {
+        "effect": "[parameters('effect')]"
+    }
+}


### PR DESCRIPTION
New Azure policy to control the disk state for Azure Snapshots.
Disallowing the diskState to be set to, for example ActiveSAS or ActiveSASFrozen will block the possibility of exporting an Azure Snapshots using SAS tokens.