### PR TITLE
Adding OpenAI Policies

### DIFF
--- a/Policies/CognitiveServices/audit-content-logging/azurepolicy.json
+++ b/Policies/CognitiveServices/audit-content-logging/azurepolicy.json
@@ -1,0 +1,53 @@
+{
+  "name": "5e68f029-0f81-4ee3-b578-705b0fdb237d",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Audit OpenAI instances with content filtering enabled",
+    "description": "Azure OpenAI Service includes a content management system that filters content. If you are working with sensitive data, content filtering should be disabled so that Microsoft is not processing your data.",
+    "metadata": {
+      "category": "Cognitive Services",
+      "version": "1.0.0"
+    },
+    "mode": "Indexed",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.CognitiveServices/accounts"
+          },
+          {
+            "field": "kind",
+            "equals": "OpenAI"
+          },
+          {
+            "anyOf": [
+              {
+                "field": "Microsoft.CognitiveServices/accounts/capabilities[*].name",
+                "notEquals": "ContentLogging"
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/CognitiveServices/audit-content-logging/azurepolicy.parameters.json
+++ b/Policies/CognitiveServices/audit-content-logging/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Deny",
+      "Disabled"
+    ],
+    "defaultValue": "Audit"
+  }
+}

--- a/Policies/CognitiveServices/audit-content-logging/azurepolicy.rules.json
+++ b/Policies/CognitiveServices/audit-content-logging/azurepolicy.rules.json
@@ -1,0 +1,25 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.CognitiveServices/accounts"
+      },
+      {
+        "field": "kind",
+        "equals": "OpenAI"
+      },
+      {
+        "anyOf": [
+          {
+            "field": "Microsoft.CognitiveServices/accounts/capabilities[*].name",
+            "notEquals": "ContentLogging"
+          }
+        ]
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}

--- a/Policies/CognitiveServices/public-access-restriction/azurepolicy.json
+++ b/Policies/CognitiveServices/public-access-restriction/azurepolicy.json
@@ -1,0 +1,73 @@
+{
+  "name": "5e68f029-0f81-4ee3-b578-705b0fdb237c",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Audit OpenAI instances public access enabled",
+    "description": "Azure OpenAI instances should not have public access enabled. Open AI instances should only be accessible via select networks or a private endpoint.",
+    "metadata": {
+      "category": "Cognitive Services",
+      "version": "1.0.0"
+    },
+    "mode": "Indexed",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Deny",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.CognitiveServices/accounts"
+          },
+          {
+            "field": "kind",
+            "equals": "OpenAI"
+          },
+          {
+            "anyof": [
+              {
+                "allof": [
+                  {
+                    "field": "Microsoft.CognitiveServices/accounts/networkAcls.defaultAction",
+                    "notEquals": "Deny"
+                  },
+                  {
+                    "field": "Microsoft.CognitiveServices/accounts/publicNetworkAccess",
+                    "equals": "Enabled"
+                  }
+                ]
+              },
+              {
+                "allof": [
+                  {
+                    "field": "Microsoft.CognitiveServices/accounts/networkAcls",
+                    "exists": "false"
+                  },
+                  {
+                    "field": "Microsoft.CognitiveServices/accounts/publicNetworkAccess",
+                    "equals": "Enabled"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/Policies/CognitiveServices/public-access-restriction/azurepolicy.parameters.json
+++ b/Policies/CognitiveServices/public-access-restriction/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Deny",
+      "Disabled"
+    ],
+    "defaultValue": "Audit"
+  }
+}

--- a/Policies/CognitiveServices/public-access-restriction/azurepolicy.rules.json
+++ b/Policies/CognitiveServices/public-access-restriction/azurepolicy.rules.json
@@ -1,0 +1,45 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.CognitiveServices/accounts"
+      },
+      {
+        "field": "kind",
+        "equals": "OpenAI"
+      },
+      {
+        "anyof": [
+          {
+            "allof": [
+              {
+                "field": "Microsoft.CognitiveServices/accounts/networkAcls.defaultAction",
+                "notEquals": "Deny"
+              },
+              {
+                "field": "Microsoft.CognitiveServices/accounts/publicNetworkAccess",
+                "equals": "Enabled"
+              }
+            ]
+          },
+          {
+            "allof": [
+              {
+                "field": "Microsoft.CognitiveServices/accounts/networkAcls",
+                "exists": "false"
+              },
+              {
+                "field": "Microsoft.CognitiveServices/accounts/publicNetworkAccess",
+                "equals": "Enabled"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}


### PR DESCRIPTION
Adding policy definitions for ensuring that OpenAI instances are not publicly accessible and for auditing which OpenAI instances have been opted out of content filtering and abuse monitoring.