### PR TITLE
Fix: Create a unique policy id

### DIFF
--- a/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
+++ b/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
@@ -161,5 +161,5 @@
 		}
 	},
 	"type": "Microsoft.Authorization/policyDefinitions",
-	"name": "b83d392d-3a11-41ac-bf39-c6ee381b9255"
+	"name": "25c202a4-16b4-403f-82d4-0dba3e3e689a"
 }


### PR DESCRIPTION
As the original if ("b83d392d-3a11-41ac-bf39-c6ee381b9255") was used for these community policies:
- policyDefinitions/Compute/deploy-linux-vm-app
- policyDefinitions/Compute/deploy-windows-vm-app