### PR TITLE
Fix: Create a unique SQL policy id

### DIFF
--- a/policyDefinitions/SQL/configure-azure-sql-db-to-use-tls-1.2/azurepolicy.json
+++ b/policyDefinitions/SQL/configure-azure-sql-db-to-use-tls-1.2/azurepolicy.json
@@ -1,5 +1,5 @@
 {
-  "name": "73290fa2-dfa7-4bbb-945d-a5e23b75df2c",
+  "name": "e7c2dace-6fe3-44e0-8f59-e4a9b100c311",
   "type": "Microsoft.Authorization/policyDefinitions",
   "properties": {
     "displayName": "Configure Azure SQL DB to use TLS 1.2",


### PR DESCRIPTION
As the original if ("73290fa2-dfa7-4bbb-945d-a5e23b75df2c") was used for these policies (community and built-in):
- policyDefinitions/SQL/configure-azure-sql-db-to-use-tls-1.2
- /providers/Microsoft.Authorization/policyDefinitions/73290fa2-dfa7-4bbb-945d-a5e23b75df2c