### PR TITLE
Feature/defender pricing tiers

### DIFF
--- a/policyDefinitions/Security Center/deploy-azure-security-center-pricing-tier/azurepolicy.json
+++ b/policyDefinitions/Security Center/deploy-azure-security-center-pricing-tier/azurepolicy.json
@@ -146,7 +146,7 @@
         "type": "String",
         "metadata": {
           "displayName": "cosmosDbsTier",
-          "description": "Specify whether you want to enable Standard tier for dns resource type"
+          "description": "Specify whether you want to enable Standard tier for cosmosDb resource type"
         },
         "allowedValues": [
           "Standard",
@@ -158,7 +158,7 @@
         "type": "String",
         "metadata": {
           "displayName": "openSourceRelationalDatabasesTier",
-          "description": "Specify whether you want to enable Standard tier for dns resource type"
+          "description": "Specify whether you want to enable Standard tier for openSourceRelationalDatabase resource type"
         },
         "allowedValues": [
           "Standard",
@@ -170,7 +170,7 @@
         "type": "String",
         "metadata": {
           "displayName": "cloudPostureTier",
-          "description": "Specify whether you want to enable Standard tier for dns resource type"
+          "description": "Specify whether you want to enable Standard tier for cloudPosture resource type"
         },
         "allowedValues": [
           "Standard",
@@ -182,7 +182,7 @@
         "type": "String",
         "metadata": {
           "displayName": "containersTier",
-          "description": "Specify whether you want to enable Standard tier for dns resource type"
+          "description": "Specify whether you want to enable Standard tier for containers resource type"
         },
         "allowedValues": [
           "Standard",

--- a/policyDefinitions/Security Center/deploy-azure-security-center-pricing-tier/azurepolicy.json
+++ b/policyDefinitions/Security Center/deploy-azure-security-center-pricing-tier/azurepolicy.json
@@ -408,7 +408,7 @@
             ]
           },
           "deployment": {
-            "location": "westeurope",
+            "location": "eastus",
             "properties": {
               "mode": "incremental",
               "parameters": {

--- a/policyDefinitions/Security Center/deploy-azure-security-center-pricing-tier/azurepolicy.json
+++ b/policyDefinitions/Security Center/deploy-azure-security-center-pricing-tier/azurepolicy.json
@@ -106,6 +106,90 @@
         ],
         "defaultValue": "Standard"
       },
+      "apiTier": {
+        "type": "String",
+        "metadata": {
+          "displayName": "apiTier",
+          "description": "Specify whether you want to enable Standard tier for api resource type"
+        },
+        "allowedValues": [
+          "Standard",
+          "Free"
+        ],
+        "defaultValue": "Standard"
+      },
+      "armTier": {
+        "type": "String",
+        "metadata": {
+          "displayName": "armTier",
+          "description": "Specify whether you want to enable Standard tier for arm resource type"
+        },
+        "allowedValues": [
+          "Standard",
+          "Free"
+        ],
+        "defaultValue": "Standard"
+      },
+      "dnsTier": {
+        "type": "String",
+        "metadata": {
+          "displayName": "dnsTier",
+          "description": "Specify whether you want to enable Standard tier for dns resource type"
+        },
+        "allowedValues": [
+          "Standard",
+          "Free"
+        ],
+        "defaultValue": "Standard"
+      },
+      "cosmosDbsTier": {
+        "type": "String",
+        "metadata": {
+          "displayName": "cosmosDbsTier",
+          "description": "Specify whether you want to enable Standard tier for dns resource type"
+        },
+        "allowedValues": [
+          "Standard",
+          "Free"
+        ],
+        "defaultValue": "Standard"
+      },
+      "openSourceRelationalDatabasesTier": {
+        "type": "String",
+        "metadata": {
+          "displayName": "openSourceRelationalDatabasesTier",
+          "description": "Specify whether you want to enable Standard tier for dns resource type"
+        },
+        "allowedValues": [
+          "Standard",
+          "Free"
+        ],
+        "defaultValue": "Standard"
+      },
+      "cloudPostureTier": {
+        "type": "String",
+        "metadata": {
+          "displayName": "cloudPostureTier",
+          "description": "Specify whether you want to enable Standard tier for dns resource type"
+        },
+        "allowedValues": [
+          "Standard",
+          "Free"
+        ],
+        "defaultValue": "Standard"
+      },
+      "containersTier": {
+        "type": "String",
+        "metadata": {
+          "displayName": "containersTier",
+          "description": "Specify whether you want to enable Standard tier for dns resource type"
+        },
+        "allowedValues": [
+          "Standard",
+          "Free"
+        ],
+        "defaultValue": "Standard"
+      },
       "effect": {
         "type": "String",
         "metadata": {
@@ -236,11 +320,95 @@
                     "equals": "VirtualMachines"
                   }
                 ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Security/pricings/pricingTier",
+                    "equals": "[parameters('apiTier')]"
+                  },
+                  {
+                    "field": "name",
+                    "equals": "Api"
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Security/pricings/pricingTier",
+                    "equals": "[parameters('armTier')]"
+                  },
+                  {
+                    "field": "name",
+                    "equals": "Arm"
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Security/pricings/pricingTier",
+                    "equals": "[parameters('dnsTier')]"
+                  },
+                  {
+                    "field": "name",
+                    "equals": "Dns"
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Security/pricings/pricingTier",
+                    "equals": "[parameters('cosmosDbsTier')]"
+                  },
+                  {
+                    "field": "name",
+                    "equals": "CosmosDbs"
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Security/pricings/pricingTier",
+                    "equals": "[parameters('openSourceRelationalDatabasesTier')]"
+                  },
+                  {
+                    "field": "name",
+                    "equals": "OpenSourceRelationalDatabases"
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Security/pricings/pricingTier",
+                    "equals": "[parameters('cloudPostureTier')]"
+                  },
+                  {
+                    "field": "name",
+                    "equals": "CloudPosture"
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Security/pricings/pricingTier",
+                    "equals": "[parameters('containersTier')]"
+                  },
+                  {
+                    "field": "name",
+                    "equals": "Containers"
+                  }
+                ]
               }
             ]
           },
           "deployment": {
-            "location": "eastus",
+            "location": "westeurope",
             "properties": {
               "mode": "incremental",
               "parameters": {
@@ -267,6 +435,27 @@
                 },
                 "keyVaultsTier": {
                   "value": "[parameters('keyVaultsTier')]"
+                },
+                "apiTier": {
+                  "value": "[parameters('apiTier')]"
+                },
+                "armTier": {
+                  "value": "[parameters('armTier')]"
+                },
+                "dnsTier": {
+                  "value": "[parameters('dnsTier')]"
+                },
+                "cosmosDbsTier": {
+                  "value": "[parameters('cosmosDbsTier')]"
+                },
+                "openSourceRelationalDatabasesTier": {
+                  "value": "[parameters('openSourceRelationalDatabasesTier')]"
+                },
+                "cloudPostureTier": {
+                  "value": "[parameters('cloudPostureTier')]"
+                },
+                "containersTier": {
+                  "value": "[parameters('containersTier')]"
                 }
               },
               "template": {
@@ -295,6 +484,27 @@
                     "type": "string"
                   },
                   "keyVaultsTier": {
+                    "type": "string"
+                  },
+                  "apiTier": {
+                    "type": "string"
+                  },
+                  "armTier": {
+                    "type": "string"
+                  },
+                  "dnsTier": {
+                    "type": "string"
+                  },
+                  "cosmosDbsTier": {
+                    "type": "string"
+                  },
+                  "openSourceRelationalDatabasesTier": {
+                    "type": "string"
+                  },
+                  "cloudPostureTier": {
+                    "type": "string"
+                  },
+                  "containersTier": {
                     "type": "string"
                   }
                 },
@@ -383,6 +593,83 @@
                     ],
                     "properties": {
                       "pricingTier": "[parameters('keyVaultsTier')]"
+                    }
+                  },
+                  {
+                    "type": "Microsoft.Security/pricings",
+                    "apiVersion": "2018-06-01",
+                    "name": "Api",
+                    "dependsOn": [
+                      "[concat('Microsoft.Security/pricings/KeyVaults')]"
+                    ],
+                    "properties": {
+                      "pricingTier": "[parameters('apiTier')]"
+                    }
+                  },
+                  {
+                    "type": "Microsoft.Security/pricings",
+                    "apiVersion": "2018-06-01",
+                    "name": "Arm",
+                    "dependsOn": [
+                      "[concat('Microsoft.Security/pricings/Api')]"
+                    ],
+                    "properties": {
+                      "pricingTier": "[parameters('armTier')]"
+                    }
+                  },
+                  {
+                    "type": "Microsoft.Security/pricings",
+                    "apiVersion": "2018-06-01",
+                    "name": "Dns",
+                    "dependsOn": [
+                      "[concat('Microsoft.Security/pricings/Arm')]"
+                    ],
+                    "properties": {
+                      "pricingTier": "[parameters('dnsTier')]"
+                    }
+                  },
+                  {
+                    "type": "Microsoft.Security/pricings",
+                    "apiVersion": "2018-06-01",
+                    "name": "CosmosDbs",
+                    "dependsOn": [
+                      "[concat('Microsoft.Security/pricings/Dns')]"
+                    ],
+                    "properties": {
+                      "pricingTier": "[parameters('cosmosDbsTier')]"
+                    }
+                  },
+                  {
+                    "type": "Microsoft.Security/pricings",
+                    "apiVersion": "2018-06-01",
+                    "name": "OpenSourceRelationalDatabases",
+                    "dependsOn": [
+                      "[concat('Microsoft.Security/pricings/CosmosDbs')]"
+                    ],
+                    "properties": {
+                      "pricingTier": "[parameters('openSourceRelationalDatabasesTier')]"
+                    }
+                  },
+                  {
+                    "type": "Microsoft.Security/pricings",
+                    "apiVersion": "2018-06-01",
+                    "name": "CloudPosture",
+                    "dependsOn": [
+                      "[concat('Microsoft.Security/pricings/OpenSourceRelationalDatabases')]"
+                    ],
+                    "properties": {
+                      "pricingTier": "[parameters('cloudPostureTier')]"
+                    }
+                  },
+                  {
+                    "type": "Microsoft.Security/pricings",
+                    "apiVersion": "2018-06-01",
+                    "name": "Containers",
+                    "dependsOn": [
+                      "[concat('Microsoft.Security/pricings/CloudPosture')]"
+                    ],
+                    "properties": {
+                      "pricingTier": "[parameters('containersTier')]"
                     }
                   }
                 ],

--- a/policyDefinitions/Security Center/deploy-azure-security-center-pricing-tier/azurepolicy.parameters.json
+++ b/policyDefinitions/Security Center/deploy-azure-security-center-pricing-tier/azurepolicy.parameters.json
@@ -135,7 +135,7 @@
     "type": "String",
     "metadata": {
       "displayName": "cosmosDbsTier",
-      "description": "Specify whether you want to enable Standard tier for dns resource type"
+      "description": "Specify whether you want to enable Standard tier for cosmosDb resource type"
     },
     "allowedValues": [
       "Standard",
@@ -147,7 +147,7 @@
     "type": "String",
     "metadata": {
       "displayName": "openSourceRelationalDatabasesTier",
-      "description": "Specify whether you want to enable Standard tier for dns resource type"
+      "description": "Specify whether you want to enable Standard tier for openSourceRelationalDatabase resource type"
     },
     "allowedValues": [
       "Standard",
@@ -159,7 +159,7 @@
     "type": "String",
     "metadata": {
       "displayName": "cloudPostureTier",
-      "description": "Specify whether you want to enable Standard tier for dns resource type"
+      "description": "Specify whether you want to enable Standard tier for cloudPosture resource type"
     },
     "allowedValues": [
       "Standard",
@@ -171,7 +171,7 @@
     "type": "String",
     "metadata": {
       "displayName": "containersTier",
-      "description": "Specify whether you want to enable Standard tier for dns resource type"
+      "description": "Specify whether you want to enable Standard tier for containers resource type"
     },
     "allowedValues": [
       "Standard",

--- a/policyDefinitions/Security Center/deploy-azure-security-center-pricing-tier/azurepolicy.parameters.json
+++ b/policyDefinitions/Security Center/deploy-azure-security-center-pricing-tier/azurepolicy.parameters.json
@@ -95,6 +95,90 @@
     ],
     "defaultValue": "Standard"
   },
+  "apiTier": {
+    "type": "String",
+    "metadata": {
+      "displayName": "apiTier",
+      "description": "Specify whether you want to enable Standard tier for api resource type"
+    },
+    "allowedValues": [
+      "Standard",
+      "Free"
+    ],
+    "defaultValue": "Standard"
+  },
+  "armTier": {
+    "type": "String",
+    "metadata": {
+      "displayName": "armTier",
+      "description": "Specify whether you want to enable Standard tier for arm resource type"
+    },
+    "allowedValues": [
+      "Standard",
+      "Free"
+    ],
+    "defaultValue": "Standard"
+  },
+  "dnsTier": {
+    "type": "String",
+    "metadata": {
+      "displayName": "dnsTier",
+      "description": "Specify whether you want to enable Standard tier for dns resource type"
+    },
+    "allowedValues": [
+      "Standard",
+      "Free"
+    ],
+    "defaultValue": "Standard"
+  },
+  "cosmosDbsTier": {
+    "type": "String",
+    "metadata": {
+      "displayName": "cosmosDbsTier",
+      "description": "Specify whether you want to enable Standard tier for dns resource type"
+    },
+    "allowedValues": [
+      "Standard",
+      "Free"
+    ],
+    "defaultValue": "Standard"
+  },
+  "openSourceRelationalDatabasesTier": {
+    "type": "String",
+    "metadata": {
+      "displayName": "openSourceRelationalDatabasesTier",
+      "description": "Specify whether you want to enable Standard tier for dns resource type"
+    },
+    "allowedValues": [
+      "Standard",
+      "Free"
+    ],
+    "defaultValue": "Standard"
+  },
+  "cloudPostureTier": {
+    "type": "String",
+    "metadata": {
+      "displayName": "cloudPostureTier",
+      "description": "Specify whether you want to enable Standard tier for dns resource type"
+    },
+    "allowedValues": [
+      "Standard",
+      "Free"
+    ],
+    "defaultValue": "Standard"
+  },
+  "containersTier": {
+    "type": "String",
+    "metadata": {
+      "displayName": "containersTier",
+      "description": "Specify whether you want to enable Standard tier for dns resource type"
+    },
+    "allowedValues": [
+      "Standard",
+      "Free"
+    ],
+    "defaultValue": "Standard"
+  },
   "effect": {
     "type": "String",
     "metadata": {

--- a/policyDefinitions/Security Center/deploy-azure-security-center-pricing-tier/azurepolicy.rules.json
+++ b/policyDefinitions/Security Center/deploy-azure-security-center-pricing-tier/azurepolicy.rules.json
@@ -114,6 +114,90 @@
                 "equals": "VirtualMachines"
               }
             ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Security/pricings/pricingTier",
+                "equals": "[parameters('apiTier')]"
+              },
+              {
+                "field": "name",
+                "equals": "Api"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Security/pricings/pricingTier",
+                "equals": "[parameters('armTier')]"
+              },
+              {
+                "field": "name",
+                "equals": "Arm"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Security/pricings/pricingTier",
+                "equals": "[parameters('dnsTier')]"
+              },
+              {
+                "field": "name",
+                "equals": "Dns"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Security/pricings/pricingTier",
+                "equals": "[parameters('cosmosDbsTier')]"
+              },
+              {
+                "field": "name",
+                "equals": "CosmosDbs"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Security/pricings/pricingTier",
+                "equals": "[parameters('openSourceRelationalDatabasesTier')]"
+              },
+              {
+                "field": "name",
+                "equals": "OpenSourceRelationalDatabases"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Security/pricings/pricingTier",
+                "equals": "[parameters('cloudPostureTier')]"
+              },
+              {
+                "field": "name",
+                "equals": "CloudPosture"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Security/pricings/pricingTier",
+                "equals": "[parameters('containersTier')]"
+              },
+              {
+                "field": "name",
+                "equals": "Containers"
+              }
+            ]
           }
         ]
       },
@@ -145,6 +229,27 @@
             },
             "keyVaultsTier": {
               "value": "[parameters('keyVaultsTier')]"
+            },
+            "apiTier": {
+              "value": "[parameters('apiTier')]"
+            },
+            "armTier": {
+              "value": "[parameters('armTier')]"
+            },
+            "dnsTier": {
+              "value": "[parameters('dnsTier')]"
+            },
+            "cosmosDbsTier": {
+              "value": "[parameters('cosmosDbsTier')]"
+            },
+            "openSourceRelationalDatabasesTier": {
+              "value": "[parameters('openSourceRelationalDatabasesTier')]"
+            },
+            "cloudPostureTier": {
+              "value": "[parameters('cloudPostureTier')]"
+            },
+            "containersTier": {
+              "value": "[parameters('containersTier')]"
             }
           },
           "template": {
@@ -173,6 +278,27 @@
                 "type": "string"
               },
               "keyVaultsTier": {
+                "type": "string"
+              },
+              "apiTier": {
+                "type": "string"
+              },
+              "armTier": {
+                "type": "string"
+              },
+              "dnsTier": {
+                "type": "string"
+              },
+              "cosmosDbsTier": {
+                "type": "string"
+              },
+              "openSourceRelationalDatabasesTier": {
+                "type": "string"
+              },
+              "cloudPostureTier": {
+                "type": "string"
+              },
+              "containersTier": {
                 "type": "string"
               }
             },
@@ -261,6 +387,83 @@
                 ],
                 "properties": {
                   "pricingTier": "[parameters('keyVaultsTier')]"
+                }
+              },
+              {
+                "type": "Microsoft.Security/pricings",
+                "apiVersion": "2018-06-01",
+                "name": "Api",
+                "dependsOn": [
+                  "[concat('Microsoft.Security/pricings/KeyVaults')]"
+                ],
+                "properties": {
+                  "pricingTier": "[parameters('apiTier')]"
+                }
+              },
+              {
+                "type": "Microsoft.Security/pricings",
+                "apiVersion": "2018-06-01",
+                "name": "Arm",
+                "dependsOn": [
+                  "[concat('Microsoft.Security/pricings/Api')]"
+                ],
+                "properties": {
+                  "pricingTier": "[parameters('armTier')]"
+                }
+              },
+              {
+                "type": "Microsoft.Security/pricings",
+                "apiVersion": "2018-06-01",
+                "name": "Dns",
+                "dependsOn": [
+                  "[concat('Microsoft.Security/pricings/Arm')]"
+                ],
+                "properties": {
+                  "pricingTier": "[parameters('dnsTier')]"
+                }
+              },
+              {
+                "type": "Microsoft.Security/pricings",
+                "apiVersion": "2018-06-01",
+                "name": "CosmosDbs",
+                "dependsOn": [
+                  "[concat('Microsoft.Security/pricings/Dns')]"
+                ],
+                "properties": {
+                  "pricingTier": "[parameters('cosmosDbsTier')]"
+                }
+              },
+              {
+                "type": "Microsoft.Security/pricings",
+                "apiVersion": "2018-06-01",
+                "name": "OpenSourceRelationalDatabases",
+                "dependsOn": [
+                  "[concat('Microsoft.Security/pricings/CosmosDbs')]"
+                ],
+                "properties": {
+                  "pricingTier": "[parameters('openSourceRelationalDatabasesTier')]"
+                }
+              },
+              {
+                "type": "Microsoft.Security/pricings",
+                "apiVersion": "2018-06-01",
+                "name": "CloudPosture",
+                "dependsOn": [
+                  "[concat('Microsoft.Security/pricings/OpenSourceRelationalDatabases')]"
+                ],
+                "properties": {
+                  "pricingTier": "[parameters('cloudPostureTier')]"
+                }
+              },
+              {
+                "type": "Microsoft.Security/pricings",
+                "apiVersion": "2018-06-01",
+                "name": "Containers",
+                "dependsOn": [
+                  "[concat('Microsoft.Security/pricings/CloudPosture')]"
+                ],
+                "properties": {
+                  "pricingTier": "[parameters('containersTier')]"
                 }
               }
             ],


### PR DESCRIPTION
Found that there were defender plans missing from this policy.
Added them.
Also included legacy plans, so that the policy can be used to decommission legacy plans.