### PR TITLE
BugFix: Address space must be pre-allocated for region

### DIFF
--- a/policyDefinitions/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.json
+++ b/policyDefinitions/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.json
@@ -83,7 +83,7 @@
                   "where": {
                     "allOf": [
                       {
-                        "value": "[string( split( string( if( empty(field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*].remoteVirtualNetwork.id')), '', field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*].remoteVirtualNetwork.id') ) ), '/' )[2]) ]",
+                        "value": "[string( split( string( field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*].remoteVirtualNetwork.id') ), '/' )[2]) ]",
                         "in": "[parameters('hubSubscriptions')]"
                       }
                     ]

--- a/policyDefinitions/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.json
+++ b/policyDefinitions/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.json
@@ -35,7 +35,8 @@
         "metadata": {
           "displayName": "(Optional) Hub Subscription IDs",
           "description": "An array of subscriptionIDs to which VNETs are peered; will cause the policy to only evaluate VNETs associated directly with your hubs."
-        }
+        },
+        "defaultValue": []
       },
       "effect": {
         "type": "String",

--- a/policyDefinitions/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.json
+++ b/policyDefinitions/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.json
@@ -83,7 +83,7 @@
                   "where": {
                     "allOf": [
                       {
-                        "value": "[split(field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*].remoteVirtualNetwork.id'), '/')[2]]",
+                        "value": "[string( split( string( if( empty(field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*].remoteVirtualNetwork.id')), '', field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*].remoteVirtualNetwork.id') ) ), '/' )[2]) ]",
                         "in": "[parameters('hubSubscriptions')]"
                       }
                     ]

--- a/policyDefinitions/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.json
+++ b/policyDefinitions/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.json
@@ -83,7 +83,7 @@
                   "where": {
                     "allOf": [
                       {
-                        "value": "[string( split( string( field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*].remoteVirtualNetwork.id') ), '/' )[2]) ]",
+                        "value": "[ split( string( field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*].remoteVirtualNetwork.id') ), '/' )[2] ]",
                         "in": "[parameters('hubSubscriptions')]"
                       }
                     ]

--- a/policyDefinitions/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.parameters.json
+++ b/policyDefinitions/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.parameters.json
@@ -23,7 +23,8 @@
     "metadata": {
       "displayName": "(Optional) Hub Subscription IDs",
       "description": "An array of subscriptionIDs to which VNETs are peered; will cause the policy to only evaluate VNETs associated directly with your hubs."
-    }
+    },
+    "defaultValue": []
   },
   "effect": {
     "type": "String",

--- a/policyDefinitions/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.rules.json
+++ b/policyDefinitions/Network/address-space-must-be-pre-allocated-for-region/azurepolicy.rules.json
@@ -29,7 +29,7 @@
               "where": {
                 "allOf": [
                   {
-                    "value": "[split(field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*].remoteVirtualNetwork.id'), '/')[2]]",
+                    "value": "[ split( string( field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings[*].remoteVirtualNetwork.id') ), '/' )[2] ]",
                     "in": "[parameters('hubSubscriptions')]"
                   }
                 ]


### PR DESCRIPTION
- Add "defaultValue" to defined "(optional)" parameter so it is not set as a required parameter when creating the Policy Assignment. 

- Add string() function to the remoteVirtualNetwork.id split to allow for it to resolve without errors.