### PR TITLE
configure-a-private-dns-zone-id-for-cognitive-services-account-groupid

### DIFF
--- a/policyDefinitions/Network/configure-a-private-dns-zone-id-for-cognitive-services-account-groupid/azurepolicy.json
+++ b/policyDefinitions/Network/configure-a-private-dns-zone-id-for-cognitive-services-account-groupid/azurepolicy.json
@@ -1,0 +1,142 @@
+{
+    "name": "5d34e716-cc45-4649-8a05-f1f7deaf2f36",
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "properties": {
+        "displayName": "Configure a private DNS Zone ID for Cognitive Services 'account' groupID",
+        "mode": "Indexed",
+        "description": "Configure private DNS zone group to override the DNS resolution for Cognitive Services 'account' groupID private endpoint. The policy distinguishes the correct Azure Private DNS Zone for Cognitive Services of kind OpenAI and other Cognitive Services. Reference: https://github.com/microsoft/industry/issues/380 Kudos @adforeman (GitHub)",
+        "metadata": {
+            "version": "1.0.0",
+            "category": "Cognitive Services"
+        },
+        "parameters": {
+            "defaultPrivateDnsZoneId": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Default Private DNS Zone ID",
+                    "description": "The default Private DNS Zone ID for Cognitive Services resources (except Azure OpenAI).",
+                    "strongType": "Microsoft.Network/privateDnsZones"
+                }
+            },
+            "openaiPrivateDnsZoneId": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "OpenAI Private DNS Zone ID",
+                    "description": "The Private DNS Zone ID for Azure OpenAI resources.",
+                    "strongType": "Microsoft.Network/privateDnsZones"
+                }
+            },
+            "effect": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "Enable or disable the execution of the policy"
+                },
+                "allowedValues": [
+                    "DeployIfNotExists",
+                    "Disabled"
+                ],
+                "defaultValue": "DeployIfNotExists"
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "equals": "Microsoft.Network/privateEndpoints",
+                        "field": "type"
+                    },
+                    {
+                        "count": {
+                            "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
+                            "where": {
+                                "allOf": [
+                                    {
+                                        "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+                                        "contains": "Microsoft.CognitiveServices/accounts"
+                                    },
+                                    {
+                                        "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+                                        "equals": "account"
+                                    }
+                                ]
+                            }
+                        },
+                        "greaterOrEquals": 1
+                    }
+                ]
+            },
+            "then": {
+                "effect": "[parameters('effect')]",
+                "details": {
+                    "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                    "roleDefinitionIds": [
+                        "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+                        "/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"
+                    ],
+                    "deployment": {
+                        "properties": {
+                            "mode": "incremental",
+                            "template": {
+                                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                "contentVersion": "1.0.0.0",
+                                "parameters": {
+                                    "defaultPrivateDnsZoneId": {
+                                        "type": "string"
+                                    },
+                                    "openaiPrivateDnsZoneId": {
+                                        "type": "string"
+                                    },
+                                    "privateEndpointName": {
+                                        "type": "string"
+                                    },
+                                    "location": {
+                                        "type": "string"
+                                    },
+                                    "privateLinkServiceId": {
+                                        "type": "array"
+                                    }
+                                },
+                                "resources": [
+                                    {
+                                        "name": "[concat(parameters('privateEndpointName'), '/deployedByPolicy')]",
+                                        "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                                        "apiVersion": "2022-07-01",
+                                        "location": "[parameters('location')]",
+                                        "properties": {
+                                            "privateDnsZoneConfigs": [
+                                                {
+                                                    "name": "privateDnsZone",
+                                                    "properties": {
+                                                        "privateDnsZoneId": "[if(equals(reference(parameters('privateLinkServiceId')[0], '2022-12-01', 'Full').kind, 'OpenAI'), parameters('openaiPrivateDnsZoneId'), parameters('defaultPrivateDnsZoneId'))]"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "parameters": {
+                                "defaultPrivateDnsZoneId": {
+                                    "value": "[parameters('defaultPrivateDnsZoneId')]"
+                                },
+                                "openaiPrivateDnsZoneId": {
+                                    "value": "[parameters('openaiPrivateDnsZoneId')]"
+                                },
+                                "privateEndpointName": {
+                                    "value": "[field('name')]"
+                                },
+                                "location": {
+                                    "value": "[field('location')]"
+                                },
+                                "privateLinkServiceId": {
+                                    "value": "[field('Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId')]"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/policyDefinitions/Network/configure-a-private-dns-zone-id-for-cognitive-services-account-groupid/azurepolicy.json
+++ b/policyDefinitions/Network/configure-a-private-dns-zone-id-for-cognitive-services-account-groupid/azurepolicy.json
@@ -2,7 +2,7 @@
     "name": "5d34e716-cc45-4649-8a05-f1f7deaf2f36",
     "type": "Microsoft.Authorization/policyDefinitions",
     "properties": {
-        "displayName": "Configure a private DNS Zone ID for Cognitive Services 'account' groupID",
+        "displayName": "Configure a private DNS Zone ID for Cognitive Services account groupID",
         "mode": "Indexed",
         "description": "Configure private DNS zone group to override the DNS resolution for Cognitive Services 'account' groupID private endpoint. The policy distinguishes the correct Azure Private DNS Zone for Cognitive Services of kind OpenAI and other Cognitive Services. Reference: https://github.com/microsoft/industry/issues/380 Kudos @adforeman (GitHub)",
         "metadata": {

--- a/policyDefinitions/Network/configure-a-private-dns-zone-id-for-cognitive-services-account-groupid/azurepolicy.parameters.json
+++ b/policyDefinitions/Network/configure-a-private-dns-zone-id-for-cognitive-services-account-groupid/azurepolicy.parameters.json
@@ -1,0 +1,30 @@
+{
+  "defaultPrivateDnsZoneId": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Default Private DNS Zone ID",
+      "description": "The default Private DNS Zone ID for Cognitive Services resources (except Azure OpenAI).",
+      "strongType": "Microsoft.Network/privateDnsZones"
+    }
+  },
+  "openaiPrivateDnsZoneId": {
+    "type": "String",
+    "metadata": {
+      "displayName": "OpenAI Private DNS Zone ID",
+      "description": "The Private DNS Zone ID for Azure OpenAI resources.",
+      "strongType": "Microsoft.Network/privateDnsZones"
+    }
+  },
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "DeployIfNotExists"
+  }
+}

--- a/policyDefinitions/Network/configure-a-private-dns-zone-id-for-cognitive-services-account-groupid/azurepolicy.rules.json
+++ b/policyDefinitions/Network/configure-a-private-dns-zone-id-for-cognitive-services-account-groupid/azurepolicy.rules.json
@@ -1,0 +1,99 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "equals": "Microsoft.Network/privateEndpoints",
+        "field": "type"
+      },
+      {
+        "count": {
+          "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
+          "where": {
+            "allOf": [
+              {
+                "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+                "contains": "Microsoft.CognitiveServices/accounts"
+              },
+              {
+                "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+                "equals": "account"
+              }
+            ]
+          }
+        },
+        "greaterOrEquals": 1
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+        "/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "defaultPrivateDnsZoneId": {
+                "type": "string"
+              },
+              "openaiPrivateDnsZoneId": {
+                "type": "string"
+              },
+              "privateEndpointName": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              },
+              "privateLinkServiceId": {
+                "type": "array"
+              }
+            },
+            "resources": [
+              {
+                "name": "[concat(parameters('privateEndpointName'), '/deployedByPolicy')]",
+                "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                "apiVersion": "2022-07-01",
+                "location": "[parameters('location')]",
+                "properties": {
+                  "privateDnsZoneConfigs": [
+                    {
+                      "name": "privateDnsZone",
+                      "properties": {
+                        "privateDnsZoneId": "[if(equals(reference(parameters('privateLinkServiceId')[0], '2022-12-01', 'Full').kind, 'OpenAI'), parameters('openaiPrivateDnsZoneId'), parameters('defaultPrivateDnsZoneId'))]"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "parameters": {
+            "defaultPrivateDnsZoneId": {
+              "value": "[parameters('defaultPrivateDnsZoneId')]"
+            },
+            "openaiPrivateDnsZoneId": {
+              "value": "[parameters('openaiPrivateDnsZoneId')]"
+            },
+            "privateEndpointName": {
+              "value": "[field('name')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            },
+            "privateLinkServiceId": {
+              "value": "[field('Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId')]"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Configure private DNS zone group to override the DNS resolution for Cognitive Services 'account' groupID private endpoint. The policy distinguishes the correct Azure Private DNS Zone for Cognitive Services of kind OpenAI and other Cognitive Services.

Reference: https://github.com/microsoft/industry/issues/380 Kudos @adforeman (GitHub)
Reference built-in policy: [Configure Cognitive Services accounts to use private DNS zones c4bc6f10-cb41-49eb-b000-d5ab82e2a091](https://www.azadvertizer.net/azpolicyadvertizer/c4bc6f10-cb41-49eb-b000-d5ab82e2a091.html)