### PR TITLE
New Policy (Azure Function App): Function apps should have basic local authentication methods disabled for FTP deployments

### DIFF
--- a/policyDefinitions/App Service/function-apps-should-have-ftp-basic-auth-disabled/azurepolicy.json
+++ b/policyDefinitions/App Service/function-apps-should-have-ftp-basic-auth-disabled/azurepolicy.json
@@ -1,0 +1,56 @@
+{
+  "name": "91e9e5aa-e64b-4124-ba4e-87e5b43f3820",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Function apps should have basic local authentication methods disabled for FTP deployments",
+    "description": "Disabling local authentication methods for FTP deployments improves security by ensuring that Function apps exclusively require Microsoft Entra identities for authentication. Learn more at: https://aka.ms/app-service-disable-basic-auth.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "App Service"
+    },
+    "mode": "Indexed",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "AuditIfNotExists or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "AuditIfNotExists"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Web/sites"
+          },
+          {
+            "field": "kind",
+            "Contains": "functionapp"
+          },
+          {
+            "field": "kind",
+            "notContains": "workflowapp"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "name": "ftp",
+          "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+          "existenceCondition": {
+            "field": "Microsoft.Web/sites/basicPublishingCredentialsPolicies/allow",
+            "equals": "false"
+          }
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/App Service/function-apps-should-have-ftp-basic-auth-disabled/azurepolicy.parameters.json
+++ b/policyDefinitions/App Service/function-apps-should-have-ftp-basic-auth-disabled/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "AuditIfNotExists or Disabled the execution of the Policy"
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/policyDefinitions/App Service/function-apps-should-have-ftp-basic-auth-disabled/azurepolicy.rules.json
+++ b/policyDefinitions/App Service/function-apps-should-have-ftp-basic-auth-disabled/azurepolicy.rules.json
@@ -1,0 +1,29 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "Contains": "functionapp"
+      },
+      {
+        "field": "kind",
+        "notContains": "workflowapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "name": "ftp",
+      "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/basicPublishingCredentialsPolicies/allow",
+        "equals": "false"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Policy

- *Name*: Function apps should have basic local authentication methods disabled for FTP deployments
- *Description*: Disabling local authentication methods for FTP deployments improves security by ensuring that Function apps exclusively require Microsoft Entra identities for authentication. Learn more at: https://aka.ms/app-service-disable-basic-auth.
- *Category*: App Service
- *Supported effect(s)*: AuditIfNotExists, Disabled
- *Parameters*: None

## Description

Audit if basic local authentication methods for FTP deployments is disabled

## Details

App Service provides basic authentication for FTP and WebDeploy clients to connect to it by using [deployment credentials](https://learn.microsoft.com/en-us/azure/app-service/deploy-configure-credentials). 
These APIs are great for browsing your site’s file system, uploading drivers and utilities, and deploying with MsBuild. However, enterprises often require more secure deployment methods than basic authentication, such as [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) authentication (see [Authentication types by deployment methods in Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/deploy-authentication-types)).
 Microsoft Entra uses OAuth 2.0 token-based authorization and has many benefits and improvements that help mitigate the issues in basic authentication. For example, OAuth access tokens have a limited usable lifetime, and are specific to the applications and resources for which they're issued, so they can't be reused. Microsoft Entra also lets you deploy from other Azure services using managed identities.
 
 Source: https://learn.microsoft.com/en-us/azure/app-service/configure-basic-auth-disable?tabs=portal
