### PR TITLE
New Policy (Azure Web Apps): Web apps should have basic local authentication methods disabled for FTP deployments

### DIFF
--- a/policyDefinitions/App Service/web-apps-should-have-ftp-basic-auth-disabled/azurepolicy.json
+++ b/policyDefinitions/App Service/web-apps-should-have-ftp-basic-auth-disabled/azurepolicy.json
@@ -1,0 +1,52 @@
+{
+  "name": "d15c0177-f092-4797-82ef-cb2ec89cf527",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "App services should have local authentication methods disabled for FTP deployments",
+    "description": "Disabling local authentication methods for FTP deployments improves security by ensuring that App Service apps exclusively require Microsoft Entra identities for authentication. Learn more at: https://aka.ms/app-service-disable-basic-auth.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "App Service"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "AuditIfNotExists or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "AuditIfNotExists"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Web/sites"
+          },
+          {
+            "field": "kind",
+            "notContains": "functionapp"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "name": "ftp",
+          "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+          "existenceCondition": {
+            "field": "Microsoft.Web/sites/basicPublishingCredentialsPolicies/allow",
+            "equals": "false"
+          }
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/App Service/web-apps-should-have-ftp-basic-auth-disabled/azurepolicy.parameters.json
+++ b/policyDefinitions/App Service/web-apps-should-have-ftp-basic-auth-disabled/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "AuditIfNotExists or Disabled the execution of the Policy"
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/policyDefinitions/App Service/web-apps-should-have-ftp-basic-auth-disabled/azurepolicy.rules.json
+++ b/policyDefinitions/App Service/web-apps-should-have-ftp-basic-auth-disabled/azurepolicy.rules.json
@@ -1,0 +1,25 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "notContains": "functionapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "name": "ftp",
+      "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/basicPublishingCredentialsPolicies/allow",
+        "equals": "false"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Policy

- *Name*: Web App should have basic local authentication methods disabled for FTP deployments
- *Description*: Disabling local authentication methods for FTP deployments improves security by ensuring that Web apps exclusively require Microsoft Entra identities for authentication. Learn more at: https://aka.ms/app-service-disable-basic-auth.
- *Category*: App Service
- *Supported effect(s)*: AuditIfNotExists, Disabled
- *Parameters*: None

## Description

Audit if basic local authentication methods for FTP deployments is disabled

## Details

App Service provides basic authentication for FTP and WebDeploy clients to connect to it by using [deployment credentials](https://learn.microsoft.com/en-us/azure/app-service/deploy-configure-credentials). 
These APIs are great for browsing your site’s file system, uploading drivers and utilities, and deploying with MsBuild. However, enterprises often require more secure deployment methods than basic authentication, such as [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) authentication (see [Authentication types by deployment methods in Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/deploy-authentication-types)).
 Microsoft Entra uses OAuth 2.0 token-based authorization and has many benefits and improvements that help mitigate the issues in basic authentication. For example, OAuth access tokens have a limited usable lifetime, and are specific to the applications and resources for which they're issued, so they can't be reused. Microsoft Entra also lets you deploy from other Azure services using managed identities.
 
 Source: https://learn.microsoft.com/en-us/azure/app-service/configure-basic-auth-disable?tabs=portal

## Contribution Rules

- [X] Contain a single Policy in a folder by itself with 3 files: azurepolicy.json, azurepolicy.rules.json, and azurepolicy.parameters.json
- [X] Used Confirm-PolicyDefinitionIsValid.ps1
- [X] Used Out-FormattedPolicyDefinition.ps1
