### PR TITLE
New Policy (Azure Kubernetes Services): Ensure ephemeral disks are used for OS disks on Agent Pools

### DIFF
--- a/policyDefinitions/Kubernetes/ensure-ephemeral-disks-are-used-for-os-disks-on-agent-pools/azurepolicy.json
+++ b/policyDefinitions/Kubernetes/ensure-ephemeral-disks-are-used-for-os-disks-on-agent-pools/azurepolicy.json
@@ -1,0 +1,45 @@
+{
+  "name": "2cec5f47-bc40-40d1-8c7d-a39d9d6808d1",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Ensure ephemeral disks are used for OS disks on Agent Pools",
+    "description": "Ephemeral OS disks are created on the local virtual machine (VM) storage and not saved to the remote Azure Storage, as when using managed OS disks.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Kubernetes"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Deny, Audit or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "Deny",
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.ContainerService/managedClusters/agentPools"
+          },
+          {
+            "field": "Microsoft.ContainerService/managedClusters/agentPools/osDiskType",
+            "notequals": "Ephemeral"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/policyDefinitions/Kubernetes/ensure-ephemeral-disks-are-used-for-os-disks-on-agent-pools/azurepolicy.parameters.json
+++ b/policyDefinitions/Kubernetes/ensure-ephemeral-disks-are-used-for-os-disks-on-agent-pools/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Deny, Audit or Disabled the execution of the Policy"
+    },
+    "allowedValues": [
+      "Deny",
+      "Audit",
+      "Disabled"
+    ],
+    "defaultValue": "Audit"
+  }
+}

--- a/policyDefinitions/Kubernetes/ensure-ephemeral-disks-are-used-for-os-disks-on-agent-pools/azurepolicy.rules.json
+++ b/policyDefinitions/Kubernetes/ensure-ephemeral-disks-are-used-for-os-disks-on-agent-pools/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.ContainerService/managedClusters/agentPools"
+      },
+      {
+        "field": "Microsoft.ContainerService/managedClusters/agentPools/osDiskType",
+        "notequals": "Ephemeral"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}


### PR DESCRIPTION
# Policy

- *Name*: Ensure ephemeral disks are used for OS disks on Agent Pools
- *Description*: Ephemeral OS disks are created on the local virtual machine (VM) storage and not saved to the remote Azure Storage, as when using managed OS disks
- *Supported effect(s)*: Deny, Audit, Disabled
- *Parameters*: None

## Description

Ensure ephemeral disks are used for OS disks on Agent Pools

## Details

Ephemeral OS disks are created on the local virtual machine (VM) storage and not saved to the remote Azure Storage, as when using managed OS disks. For more information on the performance of a managed disk, see [Disk allocation and performance](https://learn.microsoft.com/en-us/azure/virtual-machines/managed-disks-overview). Ephemeral OS disks work well for stateless workloads, where applications are tolerant of individual VM failures but are more affected by VM deployment time or reimaging of individual VM instances. With Ephemeral OS disks, you get lower read/write latency to the OS disk and faster VM reimage.

The key features of ephemeral disks are the following:

- Ideal for stateless applications and workloads.
- Supported by the Azure Marketplace, custom images, and [Azure Compute Gallery](https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries) 
- Ability to fast reset or reimage virtual machines and scale set instances to the original boot state.
- Lower latency, similar to a temporary disk.
- Ephemeral OS disks are free; you incur no storage cost for OS disks.
- Available in all Azure regions.

Source: https://learn.microsoft.com/en-us/samples/azure-samples/aks-ephemeral-os-disk/aks-ephemeral-os-disk

## Contribution Rules

- [X] Contain a single Policy in a folder by itself with 3 files: azurepolicy.json, azurepolicy.rules.json, and azurepolicy.parameters.json
- [X] Used Confirm-PolicyDefinitionIsValid.ps1
- [X] Used Out-FormattedPolicyDefinition.ps1
- [X] Effect default value alignes with convention
