### PR TITLE
New Policy (Azure Database for PostgreSQL flexible servers): PostgreSQL flexible servers should enforce SSL connections

### DIFF
--- a/policyDefinitions/SQL/postgresql-flexible-servers-should-enforce-ssl-connections/azurepolicy.json
+++ b/policyDefinitions/SQL/postgresql-flexible-servers-should-enforce-ssl-connections/azurepolicy.json
@@ -1,0 +1,44 @@
+{
+  "name": "e27a6dfc-883f-4f9e-97cc-a819fe702401",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "PostgreSQL flexible servers should enforce SSL connections",
+    "description": "Azure Database for PostgreSQL supports connecting your Azure Database for PostgreSQL server to client applications using Secure Sockets Layer (SSL). Enforcing SSL connections between your database server and your client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and your application. This configuration enforces SSL for accessing your database server.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "SQL"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "AuditIfNotExists or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "AuditIfNotExists"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "field": "type",
+        "equals": "Microsoft.DBforPostgreSQL/flexibleServers"
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.DBforPostgreSQL/flexibleServers/configurations",
+          "name": "require_secure_transport",
+          "existenceCondition": {
+            "field": "Microsoft.DBforPostgreSQL/flexibleServers/configurations/value",
+            "equals": "ON"
+          }
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/SQL/postgresql-flexible-servers-should-enforce-ssl-connections/azurepolicy.parameters.json
+++ b/policyDefinitions/SQL/postgresql-flexible-servers-should-enforce-ssl-connections/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "AuditIfNotExists or Disabled the execution of the Policy"
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/policyDefinitions/SQL/postgresql-flexible-servers-should-enforce-ssl-connections/azurepolicy.rules.json
+++ b/policyDefinitions/SQL/postgresql-flexible-servers-should-enforce-ssl-connections/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "field": "type",
+    "equals": "Microsoft.DBforPostgreSQL/flexibleServers"
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.DBforPostgreSQL/flexibleServers/configurations",
+      "name": "require_secure_transport",
+      "existenceCondition": {
+        "field": "Microsoft.DBforPostgreSQL/flexibleServers/configurations/value",
+        "equals": "ON"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Policy

- *Name*: PostgreSQL flexible servers should enforce SSL connections
- *Description*: Azure Database for PostgreSQL supports connecting your Azure Database for PostgreSQL server to client applications using Secure Sockets Layer (SSL). Enforcing SSL connections between your database server and your client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and your application. This configuration enforces SSL for accessing your database server
- *Supported effect(s)*: AuditIfNotExists, Disabled
- *Parameters*: None

## Description

Audit if PostgreSQL flexible servers enforce SSL connections

## Details

Azure Database for PostgreSQL supports connecting your Azure Database for PostgreSQL server to client applications using Secure Sockets Layer (SSL). Enforcing SSL connections between your database server and your client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and your application. This configuration enforces SSL for accessing your database server

## Contribution Rules

- [X] Contain a single Policy in a folder by itself with 3 files: azurepolicy.json, azurepolicy.rules.json, and azurepolicy.parameters.json
- [X] Used Confirm-PolicyDefinitionIsValid.ps1
- [X] Used Out-FormattedPolicyDefinition.ps1
- [X] Effect default value alignes with convention

