### PR TITLE
New Policy (Azure Database for PostgreSQL flexible servers): PostgreSQL flexible servers should log checkpoints

### DIFF
--- a/policyDefinitions/SQL/postgresql-flexible-servers-should-log-checkpoints/azurepolicy.json
+++ b/policyDefinitions/SQL/postgresql-flexible-servers-should-log-checkpoints/azurepolicy.json
@@ -1,0 +1,44 @@
+{
+  "name": "7a2deb93-6f4f-4668-8697-be314e342085",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "PostgreSQL flexible servers should log checkpoints",
+    "description": "This policy helps audit any PostgreSQL databases in your environment without log_checkpoints setting enabled.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "SQL"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "AuditIfNotExists or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "AuditIfNotExists"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "field": "type",
+        "equals": "Microsoft.DBforPostgreSQL/flexibleServers"
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.DBforPostgreSQL/flexibleServers/configurations",
+          "name": "log_checkpoints",
+          "existenceCondition": {
+            "field": "Microsoft.DBforPostgreSQL/flexibleServers/configurations/value",
+            "equals": "ON"
+          }
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/SQL/postgresql-flexible-servers-should-log-checkpoints/azurepolicy.parameters.json
+++ b/policyDefinitions/SQL/postgresql-flexible-servers-should-log-checkpoints/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "AuditIfNotExists or Disabled the execution of the Policy"
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/policyDefinitions/SQL/postgresql-flexible-servers-should-log-checkpoints/azurepolicy.rules.json
+++ b/policyDefinitions/SQL/postgresql-flexible-servers-should-log-checkpoints/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "field": "type",
+    "equals": "Microsoft.DBforPostgreSQL/flexibleServers"
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.DBforPostgreSQL/flexibleServers/configurations",
+      "name": "log_checkpoints",
+      "existenceCondition": {
+        "field": "Microsoft.DBforPostgreSQL/flexibleServers/configurations/value",
+        "equals": "ON"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Policy

- *Name*: PostgreSQL flexible servers should log checkpoints
- *Description*: This policy helps audit any PostgreSQL databases in your environment without log_checkpoints setting enabled
- *Supported effect(s)*: AuditIfNotExists, Disabled
- *Parameters*: None

## Description

This policy helps audit any PostgreSQL databases in your environment without log_checkpoints setting enabled

## Details

Enabling log_checkpoints helps the PostgreSQL Database to Log each checkpoint in turn generates query and error logs. However, access to transaction logs is not supported.
Query and error logs can be used to identify, troubleshoot, and repair configuration errors and sub-optimal performance.

## Contribution Rules

- [X] Contain a single Policy in a folder by itself with 3 files: azurepolicy.json, azurepolicy.rules.json, and azurepolicy.parameters.json
- [X] Used Confirm-PolicyDefinitionIsValid.ps1
- [X] Used Out-FormattedPolicyDefinition.ps1
- [X] Effect default value alignes with convention

