### PR TITLE
New Policy (Azure Database for PostgreSQL flexible servers): PostgreSQL flexible servers should log connections

### DIFF
--- a/policyDefinitions/SQL/postgresql-flexible-servers-should-log-connections/azurepolicy.json
+++ b/policyDefinitions/SQL/postgresql-flexible-servers-should-log-connections/azurepolicy.json
@@ -1,0 +1,44 @@
+{
+  "name": "c869af6e-714a-4efc-b750-f5462b43b9c1",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "PostgreSQL flexible servers should Log connections.",
+    "description": "This policy helps audit any PostgreSQL databases in your environment without log_connections setting enabled.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "SQL"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "AuditIfNotExists or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "AuditIfNotExists"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "field": "type",
+        "equals": "Microsoft.DBforPostgreSQL/flexibleServers"
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.DBforPostgreSQL/flexibleServers/configurations",
+          "name": "log_connections",
+          "existenceCondition": {
+            "field": "Microsoft.DBforPostgreSQL/flexibleServers/configurations/value",
+            "equals": "ON"
+          }
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/SQL/postgresql-flexible-servers-should-log-connections/azurepolicy.parameters.json
+++ b/policyDefinitions/SQL/postgresql-flexible-servers-should-log-connections/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "AuditIfNotExists or Disabled the execution of the Policy"
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/policyDefinitions/SQL/postgresql-flexible-servers-should-log-connections/azurepolicy.rules.json
+++ b/policyDefinitions/SQL/postgresql-flexible-servers-should-log-connections/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "field": "type",
+    "equals": "Microsoft.DBforPostgreSQL/flexibleServers"
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.DBforPostgreSQL/flexibleServers/configurations",
+      "name": "log_connections",
+      "existenceCondition": {
+        "field": "Microsoft.DBforPostgreSQL/flexibleServers/configurations/value",
+        "equals": "ON"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Policy

- *Name*: PostgreSQL flexible servers should log connections
- *Description*: This policy helps audit any PostgreSQL databases in your environment without log_connections setting enabled
- *Supported effect(s)*: AuditIfNotExists, Disabled
- *Parameters*: None

## Description

This policy helps audit any PostgreSQL databases in your environment without log_connections setting enabled

## Details

Enabling log_connections helps PostgreSQL Database to log attempted connection to the server, as well as successful completion of client authentication.

## Contribution Rules

- [X] Contain a single Policy in a folder by itself with 3 files: azurepolicy.json, azurepolicy.rules.json, and azurepolicy.parameters.json
- [X] Used Confirm-PolicyDefinitionIsValid.ps1
- [X] Used Out-FormattedPolicyDefinition.ps1
- [X] Effect default value alignes with convention