### PR TITLE
Add policy to configure domain-based dns zone configuration on App Service Private Endpoints

### DIFF
--- a/policyDefinitions/App Service/deploy-app-private-endpoint-private-dns-zone-link-domainbased/azurepolicy.json
+++ b/policyDefinitions/App Service/deploy-app-private-endpoint-private-dns-zone-link-domainbased/azurepolicy.json
@@ -1,0 +1,142 @@
+{
+  "name": "ceb2837a-37cc-4210-b801-e7ab055dc14f",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Configure App Service apps to use private DNS zones with corresponding domain suffix",
+    "mode": "All",
+    "description": "Use private DNS zones to override the DNS resolution for a private endpoint. A private DNS zone links a virtual network to an App Service. This policy deploys the DNS zone configuration to the private DNS zone that corresponds with the domainsuffix of the app (either azurewebsites.net or appserviceenvironment.net).",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "App Service"
+    },
+    "parameters": {
+      "privateDnsZoneIdAzureWebsites": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Private Dns Zone Id for azurewebsites.net",
+          "description": "The private DNS zone to deploy in a new private DNS zone group and link to the private endpoint for apps on azurewebsites.net",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        }
+      },
+      "privateDnsZoneIdAppServiceEnvironment": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Private Dns Zone Id for appserviceenvironment.net",
+          "description": "The private DNS zone to deploy in a new private DNS zone group and link to the private endpoint for apps on appserviceenvironment.net",
+          "strongType": "Microsoft.Network/privateDnsZones"
+        }
+      },
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/privateEndpoints"
+          },
+          {
+            "count": {
+              "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
+              "where": {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+                    "contains": "Microsoft.Web/sites"
+                  },
+                  {
+                    "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+                    "equals": "sites"
+                  }
+                ]
+              }
+            },
+            "greaterOrEquals": 1
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+          "evaluationDelay": "AfterProvisioning",
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+          ],
+          "deployment": {
+            "properties": {
+              "mode": "incremental",
+              "template": {
+                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {
+                  "privateDnsZoneIdAzureWebsites": {
+                    "type": "string"
+                  },
+                  "privateDnsZoneIdAppServiceEnvironment": {
+                    "type": "string"
+                  },
+                  "privateEndpointName": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "privateLinkServiceId": {
+                    "type": "array"
+                  }
+                },
+                "resources": [
+                  {
+                    "name": "[concat(parameters('privateEndpointName'), '/deployedByPolicy')]",
+                    "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                    "apiVersion": "2020-03-01",
+                    "location": "[parameters('location')]",
+                    "properties": {
+                      "privateDnsZoneConfigs": [
+                        {
+                          "name": "websites-privateDnsZone",
+                          "properties": {
+                            "privateDnsZoneId": "[if(endsWith(reference(parameters('privateLinkServiceId'), '2023-12-01').defaultHostname, 'appserviceenvironment.net'), parameters('privateDnsZoneIdAppServiceEnvironment'), if(endsWith(reference(parameters('privateLinkServiceId'), '2023-12-01').defaultHostname, 'azurewebsites.net'), parameters('privateDnsZoneIdAzureWebsites'), parameters('privateDnsZoneIdAzureWebsites')))]"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "parameters": {
+                "privateDnsZoneIdAzureWebsites": {
+                  "value": "[parameters('privateDnsZoneIdAzureWebsites')]"
+                },
+                "privateDnsZoneIdAppServiceEnvironment": {
+                  "value": "[parameters('privateDnsZoneIdAppServiceEnvironment')]"
+                },
+                "privateEndpointName": {
+                  "value": "[field('name')]"
+                },
+                "location": {
+                  "value": "[field('location')]"
+                },
+                "privateLinkServiceId": {
+                  "value": "[field('Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId')]"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/App Service/deploy-app-private-endpoint-private-dns-zone-link-domainbased/azurepolicy.json
+++ b/policyDefinitions/App Service/deploy-app-private-endpoint-private-dns-zone-link-domainbased/azurepolicy.json
@@ -108,7 +108,7 @@
                         {
                           "name": "websites-privateDnsZone",
                           "properties": {
-                            "privateDnsZoneId": "[if(endsWith(reference(parameters('privateLinkServiceId'), '2023-12-01').defaultHostname, 'appserviceenvironment.net'), parameters('privateDnsZoneIdAppServiceEnvironment'), if(endsWith(reference(parameters('privateLinkServiceId'), '2023-12-01').defaultHostname, 'azurewebsites.net'), parameters('privateDnsZoneIdAzureWebsites'), parameters('privateDnsZoneIdAzureWebsites')))]"
+                            "privateDnsZoneId": "[if(endsWith(reference(parameters('privateLinkServiceId')[0], '2023-12-01').defaultHostname, 'appserviceenvironment.net'), parameters('privateDnsZoneIdAppServiceEnvironment'), if(endsWith(reference(parameters('privateLinkServiceId')[0], '2023-12-01').defaultHostname, 'azurewebsites.net'), parameters('privateDnsZoneIdAzureWebsites'), parameters('privateDnsZoneIdAzureWebsites')))]"
                           }
                         }
                       ]

--- a/policyDefinitions/App Service/deploy-app-private-endpoint-private-dns-zone-link-domainbased/azurepolicy.parameters.json
+++ b/policyDefinitions/App Service/deploy-app-private-endpoint-private-dns-zone-link-domainbased/azurepolicy.parameters.json
@@ -1,0 +1,30 @@
+{
+  "privateDnsZoneIdAzureWebsites": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Private Dns Zone Id for azurewebsites.net",
+      "description": "The private DNS zone to deploy in a new private DNS zone group and link to the private endpoint for apps on azurewebsites.net",
+      "strongType": "Microsoft.Network/privateDnsZones"
+    }
+  },
+  "privateDnsZoneIdAppServiceEnvironment": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Private Dns Zone Id for appserviceenvironment.net",
+      "description": "The private DNS zone to deploy in a new private DNS zone group and link to the private endpoint for apps on appserviceenvironment.net",
+      "strongType": "Microsoft.Network/privateDnsZones"
+    }
+  },
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Enable or disable the execution of the policy"
+    },
+    "allowedValues": [
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "DeployIfNotExists"
+  }
+}

--- a/policyDefinitions/App Service/deploy-app-private-endpoint-private-dns-zone-link-domainbased/azurepolicy.rules.json
+++ b/policyDefinitions/App Service/deploy-app-private-endpoint-private-dns-zone-link-domainbased/azurepolicy.rules.json
@@ -68,7 +68,7 @@
                       {
                         "name": "websites-privateDnsZone",
                         "properties": {
-                          "privateDnsZoneId": "[if(endsWith(reference(parameters('privateLinkServiceId'), '2023-12-01').defaultHostname, 'appserviceenvironment.net'), parameters('privateDnsZoneIdAppServiceEnvironment'), if(endsWith(reference(parameters('privateLinkServiceId'), '2023-12-01').defaultHostname, 'azurewebsites.net'), parameters('privateDnsZoneIdAzureWebsites'), parameters('privateDnsZoneIdAzureWebsites')))]"
+                          "privateDnsZoneId": "[if(endsWith(reference(parameters('privateLinkServiceId')[0], '2023-12-01').defaultHostname, 'appserviceenvironment.net'), parameters('privateDnsZoneIdAppServiceEnvironment'), if(endsWith(reference(parameters('privateLinkServiceId')[0], '2023-12-01').defaultHostname, 'azurewebsites.net'), parameters('privateDnsZoneIdAzureWebsites'), parameters('privateDnsZoneIdAzureWebsites')))]"
                         }
                       }
                     ]

--- a/policyDefinitions/App Service/deploy-app-private-endpoint-private-dns-zone-link-domainbased/azurepolicy.rules.json
+++ b/policyDefinitions/App Service/deploy-app-private-endpoint-private-dns-zone-link-domainbased/azurepolicy.rules.json
@@ -1,0 +1,101 @@
+{
+  "policyRule": {
+    "if": {
+      "allOf": [
+        {
+          "field": "type",
+          "equals": "Microsoft.Network/privateEndpoints"
+        },
+        {
+          "count": {
+            "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
+            "where": {
+              "allOf": [
+                {
+                  "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+                  "contains": "Microsoft.Web/sites"
+                },
+                {
+                  "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+                  "equals": "sites"
+                }
+              ]
+            }
+          },
+          "greaterOrEquals": 1
+        }
+      ]
+    },
+    "then": {
+      "effect": "[parameters('effect')]",
+      "details": {
+        "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+        "evaluationDelay": "AfterProvisioning",
+        "roleDefinitionIds": [
+          "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+        ],
+        "deployment": {
+          "properties": {
+            "mode": "incremental",
+            "template": {
+              "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "privateDnsZoneIdAzureWebsites": {
+                  "type": "string"
+                },
+                "privateDnsZoneIdAppServiceEnvironment": {
+                  "type": "string"
+                },
+                "privateEndpointName": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                },
+                "privateLinkServiceId": {
+                  "type": "array"
+                }
+              },
+              "resources": [
+                {
+                  "name": "[concat(parameters('privateEndpointName'), '/deployedByPolicy')]",
+                  "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                  "apiVersion": "2020-03-01",
+                  "location": "[parameters('location')]",
+                  "properties": {
+                    "privateDnsZoneConfigs": [
+                      {
+                        "name": "websites-privateDnsZone",
+                        "properties": {
+                          "privateDnsZoneId": "[if(endsWith(reference(parameters('privateLinkServiceId'), '2023-12-01').defaultHostname, 'appserviceenvironment.net'), parameters('privateDnsZoneIdAppServiceEnvironment'), if(endsWith(reference(parameters('privateLinkServiceId'), '2023-12-01').defaultHostname, 'azurewebsites.net'), parameters('privateDnsZoneIdAzureWebsites'), parameters('privateDnsZoneIdAzureWebsites')))]"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "parameters": {
+              "privateDnsZoneIdAzureWebsites": {
+                "value": "[parameters('privateDnsZoneIdAzureWebsites')]"
+              },
+              "privateDnsZoneIdAppServiceEnvironment": {
+                "value": "[parameters('privateDnsZoneIdAppServiceEnvironment')]"
+              },
+              "privateEndpointName": {
+                "value": "[field('name')]"
+              },
+              "location": {
+                "value": "[field('location')]"
+              },
+              "privateLinkServiceId": {
+                "value": "[field('Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId')]"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The builtin policy [Configure App Service apps to use private DNS zones](https://www.azadvertizer.net/azpolicyadvertizer/b318f84a-b872-429b-ac6d-a01b96814452.html) does not evaluate the domain suffix used by the App Service app (azurewebsites.net versus appserviceenvironment.net).

I've created a custom policy as an improvement since it uses ARM template functions to determine the domain suffix in the defaultHostname property of the App Service App, and then determines which of the two private dns zones to use (given by the input parameters).

