### PR TITLE
New Policy (Azure App Services): App Service apps should use the latest TLS version for SCM connections

### DIFF
--- a/policyDefinitions/App Service/app-service-apps-should-use-the-latest-tls-version-for-scm-connections/azurepolicy.json
+++ b/policyDefinitions/App Service/app-service-apps-should-use-the-latest-tls-version-for-scm-connections/azurepolicy.json
@@ -1,0 +1,56 @@
+{
+  "name": "638423c3-17df-40bc-bf81-9bfa3f5cc0a7",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "App Service apps should use the latest TLS version for SCM connections",
+    "description": "Periodically, newer versions are released for TLS either due to security flaws, include additional functionality, and enhance speed. Upgrade to the latest TLS version for Function apps to take advantage of security fixes, if any, and/or new functionalities of the latest version.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "App Service"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "AuditIfNotExists or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "AuditIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "AuditIfNotExists"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Web/sites"
+          },
+          {
+            "field": "kind",
+            "notContains": "functionapp"
+          },
+          {
+            "field": "kind",
+            "notContains": "workflowapp"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.Web/sites/config",
+          "name": "web",
+          "existenceCondition": {
+            "field": "Microsoft.Web/sites/config/scmMinTlsVersion",
+            "equals": "1.2"
+          }
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/App Service/app-service-apps-should-use-the-latest-tls-version-for-scm-connections/azurepolicy.parameters.json
+++ b/policyDefinitions/App Service/app-service-apps-should-use-the-latest-tls-version-for-scm-connections/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "AuditIfNotExists or Disabled the execution of the Policy"
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/policyDefinitions/App Service/app-service-apps-should-use-the-latest-tls-version-for-scm-connections/azurepolicy.rules.json
+++ b/policyDefinitions/App Service/app-service-apps-should-use-the-latest-tls-version-for-scm-connections/azurepolicy.rules.json
@@ -1,0 +1,29 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Web/sites"
+      },
+      {
+        "field": "kind",
+        "notContains": "functionapp"
+      },
+      {
+        "field": "kind",
+        "notContains": "workflowapp"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Web/sites/config",
+      "name": "web",
+      "existenceCondition": {
+        "field": "Microsoft.Web/sites/config/scmMinTlsVersion",
+        "equals": "1.2"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Policy

- *Name*: App Service apps should use the latest TLS version for SCM connections
- *Description*: This policy helps audit any Azure Service apps should use the latest TLS version for SCM connections.
- *Supported effect(s)*: AuditIfNotExists, Disabled
- *Parameters*: None

## Description

This policy helps audit any Azure Service apps should use the latest TLS version for SCM connections

## Details

Periodically, newer versions are released for TLS either due to security flaws, include additional functionality, and enhance speed. Upgrade to the latest TLS version for Function apps to take advantage of security fixes, if any, and/or new functionalities of the latest version.

## Contribution Rules

- [X] Contain a single Policy in a folder by itself with 3 files: azurepolicy.json, azurepolicy.rules.json, and azurepolicy.parameters.json
- [X] Used Confirm-PolicyDefinitionIsValid.ps1
- [X] Used Out-FormattedPolicyDefinition.ps1
- [X] Effect default value alignes with convention