### PR TITLE
Policy does not remediate automatically on deployment of Windows VM

### DIFF
--- a/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
+++ b/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
@@ -66,8 +66,20 @@
 						"equals": "Microsoft.Compute/virtualMachines"
 					},
 					{
-						"field": "Microsoft.Compute/imageOffer",
-						"equals": "Windows"
+						"anyOf": [
+							{
+								"field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
+								"contains", "Windows"
+							},
+							{
+						                "field": "Microsoft.Compute/imageOffer",
+						                "contains": "Windows"
+							},
+							{
+								"field": "Microsoft.Compute/imagePublisher",
+								"contains": "microsoftsqlserver"
+							},
+						]
 					}
 				]
 			},

--- a/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
+++ b/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
@@ -72,8 +72,8 @@
 								"contains", "Windows"
 							},
 							{
-						                "field": "Microsoft.Compute/imageOffer",
-						                "contains": "Windows"
+								"field": "Microsoft.Compute/imageOffer",
+								"contains": "Windows"
 							},
 							{
 								"field": "Microsoft.Compute/imagePublisher",

--- a/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
+++ b/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
@@ -69,7 +69,7 @@
 						"anyOf": [
 							{
 								"field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
-								"contains", "Windows"
+								"contains": "Windows"
 							},
 							{
 								"field": "Microsoft.Compute/imageOffer",

--- a/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
+++ b/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
@@ -66,7 +66,7 @@
 						"equals": "Microsoft.Compute/virtualMachines"
 					},
 					{
-						"field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
+						"field": "Microsoft.Compute/imageOffer",
 						"equals": "Windows"
 					}
 				]

--- a/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
+++ b/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
@@ -79,6 +79,10 @@
 								"field": "Microsoft.Compute/imagePublisher",
 								"contains": "microsoftsqlserver"
 							},
+							{
+								"field": "Microsoft.Compute/imagePublisher",
+								"contains": "microsoftwindowsdesktop"
+							}
 						]
 					}
 				]


### PR DESCRIPTION
### Policy will *not* work when deploying a new VM, because of the "if" condition.

```json
{
  "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
  "equals": "Windows"
}
``` 

### Explanation

The issue is that the create payload for VMs does not include the property osType, which is evaluated in the "if" condition the Policy, which makes Policy see the resource as not applicable for a deployment until later.

### Solution

The solution is to check on the image reference, and this PR shows 1 way of doing exactly that. 

#### Other relevant info

The policy works fine "as is" for manually remediating and will also be triggered by any change to the VM (for example a resize).