### PR TITLE
Deploy a Traffic Analytics enabled Flow Log resource with target virtual network

### DIFF
--- a/policyDefinitions/Network/deploy-a-traffic-analytics-enabled-flow-log-resource-with-target-virtual-network/azurepolicy.json
+++ b/policyDefinitions/Network/deploy-a-traffic-analytics-enabled-flow-log-resource-with-target-virtual-network/azurepolicy.json
@@ -3,7 +3,7 @@
     "name": "582b01ec-5ed4-408e-ad80-d7667d7b8de2",
     "properties": {
       "displayName": "Deploy a Traffic Analytics enabled Flow Log resource with target virtual network",
-      "policyType": "BuiltIn",
+      "policyType": "Custom",
       "mode": "Indexed",
       "description": "Configures flow log with enabled Traffic Analytics for specific virtual network. It will allow to log information about IP traffic flowing through an virtual network. Virtual Netowork Flow logs help to identify unknown or undesired traffic, verify network isolation and compliance with enterprise access rules, analyze network flows from compromised IPs and network interfaces.",
       "metadata": {

--- a/policyDefinitions/Network/deploy-a-traffic-analytics-enabled-flow-log-resource-with-target-virtual-network/azurepolicy.json
+++ b/policyDefinitions/Network/deploy-a-traffic-analytics-enabled-flow-log-resource-with-target-virtual-network/azurepolicy.json
@@ -1,0 +1,277 @@
+{
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "name": "582b01ec-5ed4-408e-ad80-d7667d7b8de2",
+    "properties": {
+      "displayName": "Deploy a Traffic Analytics enabled Flow Log resource with target virtual network",
+      "policyType": "BuiltIn",
+      "mode": "Indexed",
+      "description": "Configures flow log with enabled Traffic Analytics for specific virtual network. It will allow to log information about IP traffic flowing through an virtual network. Virtual Netowork Flow logs help to identify unknown or undesired traffic, verify network isolation and compliance with enterprise access rules, analyze network flows from compromised IPs and network interfaces.",
+      "metadata": {
+        "version": "1.0.0",
+        "category": "Network"
+      },
+      "version": "1.0.0",
+      "parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Enable or disable the execution of the policy"
+          },
+          "allowedValues": ["DeployIfNotExists", "Disabled"],
+          "defaultValue": "DeployIfNotExists"
+        },
+        "vnetRegion": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Virtual Network Region",
+            "description": "This Policy will review Vnets only in the selected region. You can create other assignments to include other regions.",
+            "strongType": "location"
+          }
+        },
+        "storageId": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Storage Account",
+            "description": "The resource id of storage account where flowlogs will be sent to. It will be used for deployment purposes only. Make sure this storage account is located in the same region as the Vnet.",
+            "assignPermissions": true,
+            "strongType": "Microsoft.Storage/storageAccounts"
+          }
+        },
+        "networkWatcherRG": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Network Watchers RG",
+            "description": "The name of the resource group where the flowLog resources will be created. This will be used only if a deployment is required. This is the resource group where the Network Watchers are located.",
+            "strongType": "existingResourceGroups"
+          },
+          "defaultValue": "NetworkWatcherRG"
+        },
+        "networkWatcherName": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Network Watcher",
+            "description": "The resource id of the network watcher under which the flowLog resources will be created. Make sure it belongs to the same region as the Vnet.",
+            "strongType": "Microsoft.Network/networkWatchers"
+          }
+        },
+        "retentionDays": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Number of days to retain flowlogs",
+            "description": "The number of days for which flowlog data will be retained in storage account. If you want to retain data forever and do not want to apply any retention policy, set retention (days) to 0."
+          },
+          "defaultValue": "30"
+        },
+        "timeInterval": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Traffic analytics processing interval in minutes",
+            "description": "Traffic analytics processes blobs at the selected frequency."
+          },
+          "allowedValues": ["10", "60"],
+          "defaultValue": "10"
+        },
+        "workspaceResourceId": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Workspace resource ID",
+            "description": "Log Analytics workspace resource id",
+            "assignPermissions": true
+          }
+        },
+        "workspaceRegion": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Workspace region",
+            "description": "Log Analytics workspace region",
+            "strongType": "location"
+          }
+        },
+        "workspaceId": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Workspace ID",
+            "description": "Log Analytics workspace GUID"
+          }
+        }
+      },
+      "policyRule": {
+        "if": {
+          "allOf": [
+            {
+              "field": "type",
+              "equals": "Microsoft.Network/virtualNetworks"
+            },
+            {
+              "field": "location",
+              "equals": "[parameters('vnetRegion')]"
+            }
+          ]
+        },
+        "then": {
+          "effect": "[parameters('effect')]",
+          "details": {
+            "type": "Microsoft.Network/networkWatchers/flowlogs",
+            "resourceGroupName": "[if(empty(coalesce(field('Microsoft.Network/virtualNetworks/flowLogs'))), parameters('networkWatcherRG'), split(first(field('Microsoft.Network/virtualNetworks/flowLogs[*].id')), '/')[4])]",
+            "name": "[if(empty(coalesce(field('Microsoft.Network/virtualNetworks/flowLogs[*].id'))), 'null/null', concat(split(first(field('Microsoft.Network/virtualNetworks/flowLogs[*].id')), '/')[8], '/', split(first(field('Microsoft.Network/virtualNetworks/flowLogs[*].id')), '/')[10]))]",
+            "existenceCondition": {
+              "allOf": [
+                {
+                  "field": "Microsoft.Network/networkWatchers/flowLogs/enabled",
+                  "equals": "true"
+                },
+                {
+                  "field": "Microsoft.Network/networkWatchers/flowLogs/retentionPolicy.days",
+                  "equals": "[parameters('retentionDays')]"
+                },
+                {
+                  "field": "Microsoft.Network/networkWatchers/flowLogs/storageId",
+                  "equals": "[parameters('storageId')]"
+                },
+                {
+                  "field": "Microsoft.Network/networkWatchers/flowLogs/flowAnalyticsConfiguration.networkWatcherFlowAnalyticsConfiguration.enabled",
+                  "equals": "true"
+                },
+                {
+                  "field": "Microsoft.Network/networkWatchers/flowLogs/flowAnalyticsConfiguration.networkWatcherFlowAnalyticsConfiguration.workspaceId",
+                  "equals": "[parameters('workspaceId')]"
+                },
+                {
+                  "field": "Microsoft.Network/networkWatchers/flowLogs/flowAnalyticsConfiguration.networkWatcherFlowAnalyticsConfiguration.trafficAnalyticsInterval",
+                  "equals": "[parameters('timeInterval')]"
+                }
+              ]
+            },
+            "roleDefinitionIds": [
+              "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+            ],
+            "deployment": {
+              "properties": {
+                "mode": "incremental",
+                "template": {
+                  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "parameters": {
+                    "storageId": {
+                      "type": "string"
+                    },
+                    "networkWatcherRG": {
+                      "type": "string"
+                    },
+                    "networkWatcherName": {
+                      "type": "string"
+                    },
+                    "flowlogName": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "targetResource": {
+                      "type": "string"
+                    },
+                    "retentionDays": {
+                      "type": "string"
+                    },
+                    "timeInterval": {
+                      "type": "String"
+                    },
+                    "workspaceId": {
+                      "type": "String"
+                    },
+                    "workspaceRegion": {
+                      "type": "String"
+                    },
+                    "workspaceResourceId": {
+                      "type": "String"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.Resources/deployments",
+                      "name": "[concat('flowlogDeployment-', uniqueString(parameters('flowlogName')))]",
+                      "apiVersion": "2022-09-01",
+                      "resourceGroup": "[parameters('networkWatcherRG')]",
+                      "properties": {
+                        "mode": "incremental",
+                        "parameters": {},
+                        "template": {
+                          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "parameters": {},
+                          "resources": [
+                            {
+                              "type": "Microsoft.Network/networkWatchers/flowLogs",
+                              "name": "[concat(parameters('networkWatcherName'), '/', parameters('flowlogName'))]",
+                              "apiVersion": "2022-09-01",
+                              "location": "[parameters('location')]",
+                              "properties": {
+                                "targetResourceId": "[parameters('targetResource')]",
+                                "storageId": "[parameters('storageId')]",
+                                "enabled": "true",
+                                "retentionPolicy": {
+                                  "days": "[parameters('retentionDays')]",
+                                  "enabled": "true"
+                                },
+                                "flowAnalyticsConfiguration": {
+                                  "networkWatcherFlowAnalyticsConfiguration": {
+                                    "enabled": true,
+                                    "workspaceId": "[parameters('workspaceId')]",
+                                    "workspaceRegion": "[parameters('workspaceRegion')]",
+                                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                                    "trafficAnalyticsInterval": "[parameters('timeInterval')]"
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "parameters": {
+                  "storageId": {
+                    "value": "[parameters('storageId')]"
+                  },
+                  "networkWatcherRG": {
+                    "value": "[if(empty(coalesce(field('Microsoft.Network/virtualNetworks/flowLogs'))), parameters('networkWatcherRG'), split(first(field('Microsoft.Network/virtualNetworks/flowLogs[*].id')), '/')[4])]"
+                  },
+                  "networkWatcherName": {
+                    "value": "[if(empty(coalesce(field('Microsoft.Network/virtualNetworks/flowLogs'))), last(split(parameters('networkWatcherName'), '/')), split(first(field('Microsoft.Network/virtualNetworks/flowLogs[*].id')), '/')[8])]"
+                  },
+                  "flowlogName": {
+                    "value": "[if(empty(coalesce(field('Microsoft.Network/virtualNetworks/flowLogs'))), concat(take(concat(field('name'), '-', resourceGroup().name), 72), '-', 'flowlog'), split(first(field('Microsoft.Network/virtualNetworks/flowLogs[*].id')), '/')[10])]"
+                  },
+                  "location": {
+                    "value": "[field('location')]"
+                  },
+                  "targetResource": {
+                    "value": "[concat(resourceGroup().id, '/providers/Microsoft.Network/virtualNetworks/', field('name'))]"
+                  },
+                  "retentionDays": {
+                    "value": "[parameters('retentionDays')]"
+                  },
+                  "timeInterval": {
+                    "value": "[parameters('timeInterval')]"
+                  },
+                  "workspaceId": {
+                    "value": "[parameters('workspaceId')]"
+                  },
+                  "workspaceRegion": {
+                    "value": "[parameters('workspaceRegion')]"
+                  },
+                  "workspaceResourceId": {
+                    "value": "[parameters('workspaceResourceId')]"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "versions": ["1.0.0"]
+    }
+  }
+  

--- a/policyDefinitions/Network/deploy-a-traffic-analytics-enabled-flow-log-resource-with-target-virtual-network/azurepolicy.json
+++ b/policyDefinitions/Network/deploy-a-traffic-analytics-enabled-flow-log-resource-with-target-virtual-network/azurepolicy.json
@@ -3,7 +3,6 @@
     "name": "582b01ec-5ed4-408e-ad80-d7667d7b8de2",
     "properties": {
       "displayName": "Deploy a Traffic Analytics enabled Flow Log resource with target virtual network",
-      "policyType": "Custom",
       "mode": "Indexed",
       "description": "Configures flow log with enabled Traffic Analytics for specific virtual network. It will allow to log information about IP traffic flowing through an virtual network. Virtual Netowork Flow logs help to identify unknown or undesired traffic, verify network isolation and compliance with enterprise access rules, analyze network flows from compromised IPs and network interfaces.",
       "metadata": {

--- a/policyDefinitions/Network/deploy-a-traffic-analytics-enabled-flow-log-resource-with-target-virtual-network/azurepolicy.parameters.json
+++ b/policyDefinitions/Network/deploy-a-traffic-analytics-enabled-flow-log-resource-with-target-virtual-network/azurepolicy.parameters.json
@@ -1,0 +1,86 @@
+{
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Enable or disable the execution of the policy"
+      },
+      "allowedValues": ["DeployIfNotExists", "Disabled"],
+      "defaultValue": "DeployIfNotExists"
+    },
+    "vnetRegion": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Virtual Network Region",
+        "description": "This Policy will review Vnets only in the selected region. You can create other assignments to include other regions.",
+        "strongType": "location"
+      }
+    },
+    "storageId": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Storage Account",
+        "description": "The resource id of storage account where flowlogs will be sent to. It will be used for deployment purposes only. Make sure this storage account is located in the same region as the Vnet.",
+        "assignPermissions": true,
+        "strongType": "Microsoft.Storage/storageAccounts"
+      }
+    },
+    "networkWatcherRG": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Network Watchers RG",
+        "description": "The name of the resource group where the flowLog resources will be created. This will be used only if a deployment is required. This is the resource group where the Network Watchers are located.",
+        "strongType": "existingResourceGroups"
+      },
+      "defaultValue": "NetworkWatcherRG"
+    },
+    "networkWatcherName": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Network Watcher",
+        "description": "The resource id of the network watcher under which the flowLog resources will be created. Make sure it belongs to the same region as the Vnet.",
+        "strongType": "Microsoft.Network/networkWatchers"
+      }
+    },
+    "retentionDays": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Number of days to retain flowlogs",
+        "description": "The number of days for which flowlog data will be retained in storage account. If you want to retain data forever and do not want to apply any retention policy, set retention (days) to 0."
+      },
+      "defaultValue": "30"
+    },
+    "timeInterval": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Traffic analytics processing interval in minutes",
+        "description": "Traffic analytics processes blobs at the selected frequency."
+      },
+      "allowedValues": ["10", "60"],
+      "defaultValue": "10"
+    },
+    "workspaceResourceId": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Workspace resource ID",
+        "description": "Log Analytics workspace resource id",
+        "assignPermissions": true
+      }
+    },
+    "workspaceRegion": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Workspace region",
+        "description": "Log Analytics workspace region",
+        "strongType": "location"
+      }
+    },
+    "workspaceId": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Workspace ID",
+        "description": "Log Analytics workspace GUID"
+      }
+    }
+  }
+  

--- a/policyDefinitions/Network/deploy-a-traffic-analytics-enabled-flow-log-resource-with-target-virtual-network/azurepolicy.rules.json
+++ b/policyDefinitions/Network/deploy-a-traffic-analytics-enabled-flow-log-resource-with-target-virtual-network/azurepolicy.rules.json
@@ -1,0 +1,176 @@
+{
+    "if": {
+      "allOf": [
+        {
+          "field": "type",
+          "equals": "Microsoft.Network/virtualNetworks"
+        },
+        {
+          "field": "location",
+          "equals": "[parameters('vnetRegion')]"
+        }
+      ]
+    },
+    "then": {
+      "effect": "[parameters('effect')]",
+      "details": {
+        "type": "Microsoft.Network/networkWatchers/flowlogs",
+        "resourceGroupName": "[if(empty(coalesce(field('Microsoft.Network/virtualNetworks/flowLogs'))), parameters('networkWatcherRG'), split(first(field('Microsoft.Network/virtualNetworks/flowLogs[*].id')), '/')[4])]",
+        "name": "[if(empty(coalesce(field('Microsoft.Network/virtualNetworks/flowLogs[*].id'))), 'null/null', concat(split(first(field('Microsoft.Network/virtualNetworks/flowLogs[*].id')), '/')[8], '/', split(first(field('Microsoft.Network/virtualNetworks/flowLogs[*].id')), '/')[10]))]",
+        "existenceCondition": {
+          "allOf": [
+            {
+              "field": "Microsoft.Network/networkWatchers/flowLogs/enabled",
+              "equals": "true"
+            },
+            {
+              "field": "Microsoft.Network/networkWatchers/flowLogs/retentionPolicy.days",
+              "equals": "[parameters('retentionDays')]"
+            },
+            {
+              "field": "Microsoft.Network/networkWatchers/flowLogs/storageId",
+              "equals": "[parameters('storageId')]"
+            },
+            {
+              "field": "Microsoft.Network/networkWatchers/flowLogs/flowAnalyticsConfiguration.networkWatcherFlowAnalyticsConfiguration.enabled",
+              "equals": "true"
+            },
+            {
+              "field": "Microsoft.Network/networkWatchers/flowLogs/flowAnalyticsConfiguration.networkWatcherFlowAnalyticsConfiguration.workspaceId",
+              "equals": "[parameters('workspaceId')]"
+            },
+            {
+              "field": "Microsoft.Network/networkWatchers/flowLogs/flowAnalyticsConfiguration.networkWatcherFlowAnalyticsConfiguration.trafficAnalyticsInterval",
+              "equals": "[parameters('timeInterval')]"
+            }
+          ]
+        },
+        "roleDefinitionIds": [
+          "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+        ],
+        "deployment": {
+          "properties": {
+            "mode": "incremental",
+            "template": {
+              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "storageId": {
+                  "type": "string"
+                },
+                "networkWatcherRG": {
+                  "type": "string"
+                },
+                "networkWatcherName": {
+                  "type": "string"
+                },
+                "flowlogName": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                },
+                "targetResource": {
+                  "type": "string"
+                },
+                "retentionDays": {
+                  "type": "string"
+                },
+                "timeInterval": {
+                  "type": "String"
+                },
+                "workspaceId": {
+                  "type": "String"
+                },
+                "workspaceRegion": {
+                  "type": "String"
+                },
+                "workspaceResourceId": {
+                  "type": "String"
+                }
+              },
+              "resources": [
+                {
+                  "type": "Microsoft.Resources/deployments",
+                  "name": "[concat('flowlogDeployment-', uniqueString(parameters('flowlogName')))]",
+                  "apiVersion": "2022-09-01",
+                  "resourceGroup": "[parameters('networkWatcherRG')]",
+                  "properties": {
+                    "mode": "incremental",
+                    "parameters": {},
+                    "template": {
+                      "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                      "contentVersion": "1.0.0.0",
+                      "parameters": {},
+                      "resources": [
+                        {
+                          "type": "Microsoft.Network/networkWatchers/flowLogs",
+                          "name": "[concat(parameters('networkWatcherName'), '/', parameters('flowlogName'))]",
+                          "apiVersion": "2022-09-01",
+                          "location": "[parameters('location')]",
+                          "properties": {
+                            "targetResourceId": "[parameters('targetResource')]",
+                            "storageId": "[parameters('storageId')]",
+                            "enabled": "true",
+                            "retentionPolicy": {
+                              "days": "[parameters('retentionDays')]",
+                              "enabled": "true"
+                            },
+                            "flowAnalyticsConfiguration": {
+                              "networkWatcherFlowAnalyticsConfiguration": {
+                                "enabled": true,
+                                "workspaceId": "[parameters('workspaceId')]",
+                                "workspaceRegion": "[parameters('workspaceRegion')]",
+                                "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                                "trafficAnalyticsInterval": "[parameters('timeInterval')]"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "parameters": {
+              "storageId": {
+                "value": "[parameters('storageId')]"
+              },
+              "networkWatcherRG": {
+                "value": "[if(empty(coalesce(field('Microsoft.Network/virtualNetworks/flowLogs'))), parameters('networkWatcherRG'), split(first(field('Microsoft.Network/virtualNetworks/flowLogs[*].id')), '/')[4])]"
+              },
+              "networkWatcherName": {
+                "value": "[if(empty(coalesce(field('Microsoft.Network/virtualNetworks/flowLogs'))), last(split(parameters('networkWatcherName'), '/')), split(first(field('Microsoft.Network/virtualNetworks/flowLogs[*].id')), '/')[8])]"
+              },
+              "flowlogName": {
+                "value": "[if(empty(coalesce(field('Microsoft.Network/virtualNetworks/flowLogs'))), concat(take(concat(field('name'), '-', resourceGroup().name), 72), '-', 'flowlog'), split(first(field('Microsoft.Network/virtualNetworks/flowLogs[*].id')), '/')[10])]"
+              },
+              "location": {
+                "value": "[field('location')]"
+              },
+              "targetResource": {
+                "value": "[concat(resourceGroup().id, '/providers/Microsoft.Network/virtualNetworks/', field('name'))]"
+              },
+              "retentionDays": {
+                "value": "[parameters('retentionDays')]"
+              },
+              "timeInterval": {
+                "value": "[parameters('timeInterval')]"
+              },
+              "workspaceId": {
+                "value": "[parameters('workspaceId')]"
+              },
+              "workspaceRegion": {
+                "value": "[parameters('workspaceRegion')]"
+              },
+              "workspaceResourceId": {
+                "value": "[parameters('workspaceResourceId')]"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  


### PR DESCRIPTION
There's a built-in Policy Definition 'Deploy a Flow Log resource with target virtual network' that can enable Flow Logging for virtual networks to a storage account. However, it doesn't support logging to a Log Analytics workspace.

There's a Community Policy 'Deploy a traffic analytics enabled flow log resource with target tagged network security group' that supports this, but only for NSG Flow Logging, not virtual network Flow Logging.

I combined built-in and Community Policy to support virtual network Flow Logging to a Log Analytics workspace.