### PR TITLE
Add audit policy for resource access from other services and tenants

### DIFF
--- a/policyDefinitions/SQL/audit-allow-azure-services-and-resources-to-access-this-server/azurepolicy.json
+++ b/policyDefinitions/SQL/audit-allow-azure-services-and-resources-to-access-this-server/azurepolicy.json
@@ -1,0 +1,45 @@
+{
+  "name": "e369a998-a653-4e19-a058-a6256c3f999b",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": { 
+    "displayName": "Audit Allow Azure services and resources to access this server",
+    "description": "This option configures the firewall to allow connections from IP addresses allocated to any Azure service or asset, including connections from the subscriptions of other customers. Rather than allowing any service in any tenant to access this server, network access should be limited using the virtual network option or private access.",
+    "metadata": {
+      "category": "SQL",
+      "version": "1.0.0",
+      "preview": true
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Audit or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Sql/servers/firewallrules"
+          },
+          {
+            "field": "name",
+            "like": "AllowAllWindowsAzureIps"
+          }
+        ]
+      },  
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/policyDefinitions/SQL/audit-allow-azure-services-and-resources-to-access-this-server/azurepolicy.parameters.json
+++ b/policyDefinitions/SQL/audit-allow-azure-services-and-resources-to-access-this-server/azurepolicy.parameters.json
@@ -1,0 +1,14 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Audit or Disabled the execution of the Policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Disabled"
+    ],
+    "defaultValue": "Audit"
+  }
+}

--- a/policyDefinitions/SQL/audit-allow-azure-services-and-resources-to-access-this-server/azurepolicy.rules.json
+++ b/policyDefinitions/SQL/audit-allow-azure-services-and-resources-to-access-this-server/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Sql/servers/firewallrules"
+      },
+      {
+        "field": "name",
+        "like": "AllowAllWindowsAzureIps"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}


### PR DESCRIPTION
Hi!

Added an audit policy to more easily audit instances where SQL servers are configured to allow incoming network connections from other services within the same tenant or any Azure tenant. This configuration can be unintended, and one may not always realize the consequence of such a configuration.