### PR TITLE
FIX: Ensure '$definition' is Hashtable in 'Format-PolicyDefinition'

### DIFF
--- a/Scripts/Format-PolicyDefinition.ps1
+++ b/Scripts/Format-PolicyDefinition.ps1
@@ -190,8 +190,15 @@ function Format-PolicyDefinition {
         if (!(Test-Json $content -ErrorAction SilentlyContinue)) {
             throw "'$($file.FullName)' is not valid JSON."
         }
-        #$definition = ConvertFrom-Json $content -AsHashtable -Depth 100
-        $definition = $content | ConvertFrom-Json
+        
+        # test if there are keys that differ only by casing
+        try {
+            $test = $content | ConvertFrom-Json
+        }
+        catch {
+            throw $_.Exception.Message
+        }
+        $definition = ConvertFrom-Json $content -AsHashtable -Depth 100
         #region fix tolerate flat or nested properties structure, wrong capiatalization of property members
 
         $properties = $definition


### PR DESCRIPTION
This pull request includes a significant change to the `Format-PolicyDefinition` function in the `Scripts/Format-PolicyDefinition.ps1` file. The primary focus is on improving error handling and ensuring the JSON content is correctly parsed.

Key changes include:

* Added a try-catch block to handle exceptions when converting JSON content, ensuring any errors are caught and their messages are thrown. (`Scripts/Format-PolicyDefinition.ps1`)
* Restored the use of `ConvertFrom-Json` with `-AsHashtable` and `-Depth 100` to handle the JSON conversion more robustly. (`Scripts/Format-PolicyDefinition.ps1`)table, we cannot remove keys one by one, causing the script to fail.