### PR TITLE
Fix: Append AKS API IP Restrictions is not working (#465)

### DIFF
--- a/policyDefinitions/Kubernetes/append-aks-api-ip-restrictions/azurepolicy.json
+++ b/policyDefinitions/Kubernetes/append-aks-api-ip-restrictions/azurepolicy.json
@@ -6,7 +6,7 @@
     "description": "This policy will restrict access to the AKS API server as documented here: https://docs.microsoft.com/en-us/azure/aks/api-server-authorized-ip-ranges",
     "metadata": {
       "category": "Kubernetes",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "mode": "Indexed",
     "parameters": {
@@ -23,19 +23,42 @@
           "displayName": "Effect",
           "description": "Append, Deny, Audit or Disable the execution of the Policy"
         },
-        "allowedValues": [
-          "Append",
-          "Deny",
-          "Audit",
-          "Disabled"
-        ],
+        "allowedValues": ["Append", "Deny", "Audit", "Disabled"],
         "defaultValue": "Append"
       }
     },
     "policyRule": {
       "if": {
-        "field": "type",
-        "equals": "Microsoft.ContainerService/managedClusters"
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.ContainerService/managedClusters"
+          },
+          {
+            "anyOf": [
+              {
+                "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges",
+                "exists": "false"
+              },
+              {
+                "count": {
+                  "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges[*]",
+                  "where": {
+                    "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges[*]",
+                    "in": "[parameters('listOfAllowedIps')]"
+                  }
+                },
+                "less": "[length(parameters('listOfAllowedIps'))]"
+              },
+              {
+                "count": {
+                  "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges[*]"
+                },
+                "notEquals": "[length(parameters('listOfAllowedIps'))]"
+              }
+            ]
+          }
+        ]
       },
       "then": {
         "effect": "[parameters('effect')]",

--- a/policyDefinitions/Kubernetes/append-aks-api-ip-restrictions/azurepolicy.parameters.json
+++ b/policyDefinitions/Kubernetes/append-aks-api-ip-restrictions/azurepolicy.parameters.json
@@ -1,18 +1,18 @@
 {
-      "listOfAllowedIps": {
-        "type": "Array",
-        "metadata": {
-          "displayName": "Allowed IP's",
-          "description": "A list of IP's that are allowed to access the AKS API server."
-        }
-      },
-      "effect": {
-        "type": "String",
-        "metadata": {
-          "displayName": "Effect",
-          "description": "Append, Deny, Audit or Disable the execution of the Policy"
-        },
-        "allowedValues": ["Append", "Deny", "Audit", "Disabled"],
-        "defaultValue": "Append"
-      }
+  "listOfAllowedIps": {
+    "type": "Array",
+    "metadata": {
+      "displayName": "Allowed IP's",
+      "description": "A list of IP's that are allowed to access the AKS API server."
     }
+  },
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Append, Deny, Audit or Disable the execution of the Policy"
+    },
+    "allowedValues": ["Append", "Deny", "Audit", "Disabled"],
+    "defaultValue": "Append"
+  }
+}

--- a/policyDefinitions/Kubernetes/append-aks-api-ip-restrictions/azurepolicy.parameters.json
+++ b/policyDefinitions/Kubernetes/append-aks-api-ip-restrictions/azurepolicy.parameters.json
@@ -1,23 +1,18 @@
 {
-  "listOfAllowedIps": {
-    "type": "Array",
-    "metadata": {
-      "displayName": "Allowed IP's",
-      "description": "A list of IP's that are allowed to access the AKS API server."
+      "listOfAllowedIps": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Allowed IP's",
+          "description": "A list of IP's that are allowed to access the AKS API server."
+        }
+      },
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Append, Deny, Audit or Disable the execution of the Policy"
+        },
+        "allowedValues": ["Append", "Deny", "Audit", "Disabled"],
+        "defaultValue": "Append"
+      }
     }
-  },
-  "effect": {
-    "type": "String",
-    "metadata": {
-      "displayName": "Effect",
-      "description": "Append, Deny, Audit or Disable the execution of the Policy"
-    },
-    "allowedValues": [
-      "Append",
-      "Deny",
-      "Audit",
-      "Disabled"
-    ],
-    "defaultValue": "Append"
-  }
-}

--- a/policyDefinitions/Kubernetes/append-aks-api-ip-restrictions/azurepolicy.rules.json
+++ b/policyDefinitions/Kubernetes/append-aks-api-ip-restrictions/azurepolicy.rules.json
@@ -1,43 +1,43 @@
 {
-      "if": {
-        "allOf": [
-          {
-            "field": "type",
-            "equals": "Microsoft.ContainerService/managedClusters"
-          },
-          {
-            "anyOf": [
-              {
-                "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges",
-                "exists": "false"
-              },
-              {
-                "count": {
-                  "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges[*]",
-                  "where": {
-                    "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges[*]",
-                    "in": "[parameters('listOfAllowedIps')]"
-                  }
-                },
-                "less": "[length(parameters('listOfAllowedIps'))]"
-              },
-              {
-                "count": {
-                  "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges[*]"
-                },
-                "notEquals": "[length(parameters('listOfAllowedIps'))]"
-              }
-            ]
-          }
-        ]
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.ContainerService/managedClusters"
       },
-      "then": {
-        "effect": "[parameters('effect')]",
-        "details": [
+      {
+        "anyOf": [
           {
             "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges",
-            "value": "[parameters('listOfAllowedIps')]"
+            "exists": "false"
+          },
+          {
+            "count": {
+              "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges[*]",
+              "where": {
+                "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges[*]",
+                "in": "[parameters('listOfAllowedIps')]"
+              }
+            },
+            "less": "[length(parameters('listOfAllowedIps'))]"
+          },
+          {
+            "count": {
+              "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges[*]"
+            },
+            "notEquals": "[length(parameters('listOfAllowedIps'))]"
           }
         ]
       }
-    }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": [
+      {
+        "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges",
+        "value": "[parameters('listOfAllowedIps')]"
+      }
+    ]
+  }
+}

--- a/policyDefinitions/Kubernetes/append-aks-api-ip-restrictions/azurepolicy.rules.json
+++ b/policyDefinitions/Kubernetes/append-aks-api-ip-restrictions/azurepolicy.rules.json
@@ -1,15 +1,43 @@
 {
-  "if": {
-    "field": "type",
-    "equals": "Microsoft.ContainerService/managedClusters"
-  },
-  "then": {
-    "effect": "[parameters('effect')]",
-    "details": [
-      {
-        "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges",
-        "value": "[parameters('listOfAllowedIps')]"
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.ContainerService/managedClusters"
+          },
+          {
+            "anyOf": [
+              {
+                "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges",
+                "exists": "false"
+              },
+              {
+                "count": {
+                  "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges[*]",
+                  "where": {
+                    "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges[*]",
+                    "in": "[parameters('listOfAllowedIps')]"
+                  }
+                },
+                "less": "[length(parameters('listOfAllowedIps'))]"
+              },
+              {
+                "count": {
+                  "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges[*]"
+                },
+                "notEquals": "[length(parameters('listOfAllowedIps'))]"
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": [
+          {
+            "field": "Microsoft.ContainerService/managedClusters/apiServerAccessProfile.authorizedIPRanges",
+            "value": "[parameters('listOfAllowedIps')]"
+          }
+        ]
       }
-    ]
-  }
-}
+    }


### PR DESCRIPTION
This PR addresses the issue "Append AKS API IP Restrictions is not working" in the policy file policyDefinitions/Kubernetes/append-aks-api-ip-restrictions. 

The proposed changes fix the handling of authorizedIPRanges to ensure proper IP restrictions when creating and updating resources.

### Tests Conducted:

**When creating the resource:**

If authorizedIPRanges is not added, the policy appends the required IPs automatically and allows resource creation.
If authorizedIPRanges is added but some required IPs are missing, the policy blocks resource creation.
If all required IPs are correctly added, the policy allows the resource creation.

**After the resource is created:**

Adding new IPs is blocked by the policy.
Removing IPs is blocked by the policy.
If the same number of IPs is present but one is different, the policy blocks the update.
These changes ensure that IP restrictions are enforced consistently during and after resource creation.