### PR TITLE
Ensure policy checks all Virtual Network IDs for compliance with Private DNS Zones Virtual Network Links before marking compliant.

### DIFF
--- a/policyDefinitions/Network/create-private-dns-zone-virtual-network-link-to-virtual-networks-if-not-available/azurepolicy.json
+++ b/policyDefinitions/Network/create-private-dns-zone-virtual-network-link-to-virtual-networks-if-not-available/azurepolicy.json
@@ -58,8 +58,14 @@
                 "field": "type"
               },
               {
-                "in": "[parameters('virtualNetworkResourceId')]",
-                "field": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/virtualNetwork.id"
+                "count": {
+                  "value": "[parameters('virtualNetworkResourceId')]",
+                  "where": {
+                    "field": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/virtualNetwork.id",
+                    "equals": "[current()]"
+                  }
+                },
+                "equals": "[length(parameters('virtualNetworkResourceId'))]"
               }
             ]
           },

--- a/policyDefinitions/Network/create-private-dns-zone-virtual-network-link-to-virtual-networks-if-not-available/azurepolicy.rules.json
+++ b/policyDefinitions/Network/create-private-dns-zone-virtual-network-link-to-virtual-networks-if-not-available/azurepolicy.rules.json
@@ -16,8 +16,14 @@
             "field": "type"
           },
           {
-            "in": "[parameters('virtualNetworkResourceId')]",
-            "field": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/virtualNetwork.id"
+            "count": {
+              "value": "[parameters('virtualNetworkResourceId')]",
+              "where": {
+                "field": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/virtualNetwork.id",
+                "equals": "[current()]"
+              }
+            },
+            "equals": "[length(parameters('virtualNetworkResourceId'))]"
           }
         ]
       },


### PR DESCRIPTION
Update to validate all Virtual Network IDs in the `virtualNetworkResourceId` parameter for existence in Private DNS Zones Virtual Network Links.

Previously, the policy would mark the compliance state as "compliant" if it found just one valid Private DNS Zones Virtual Network Link in the `virtualNetworkResourceId` parameter. This behavior caused an issue where newly added Virtual Network Links were never picked up during remediation tasks because the compliance state remained "compliant."

With this update, the policy will remain "non-compliant" until all Virtual Network IDs specified in the `virtualNetworkResourceId` parameter exist in the Virtual Network Links for the Private DNS Zones.
