### PR TITLE
Fix for trailing backslash validation issue. 

### DIFF
--- a/.github/workflows/confirm-policy-definition-no-built-in-conflicts.yaml
+++ b/.github/workflows/confirm-policy-definition-no-built-in-conflicts.yaml
@@ -39,8 +39,15 @@ jobs:
 
           echo "   Info: changed files converted to array, ready to check each file..."
 
-          for file in "${files[@]}"; do
-            echo "      Checking file name: ${file}"
+          for rawfile in "${files[@]}"; do
+            echo "      Checking file name: ${rawfile}"
+
+            # Trim backspaces from the file name
+            file=$(echo $rawfile | tr -d '\\')
+
+            echo "      Trimmed file name: ${file}"
+            echo ""
+
             if echo "$file" | grep -q 'github/workflows'; then
               echo '   \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/////////////////////////////////'
               echo '   |                                                                |'


### PR DESCRIPTION
#475 

Add trim delete to file path, removing trailing \ when present. 

- Tests Ran:
  - file name including appended '\\' `Result: the trailing backslash is removed`
  - file name not including '\\' `Result: no changes made to file path`  
  - file name actually includes a trailing '\\' (actually part of the file name) `Result: the check will fail with an invalid file path error. `