### PR TITLE
Adding new policy definition to handle custom roles with exclusionlist

### DIFF
--- a/policyDefinitions/Authorization/deny-custom-roles-with-exclusionlist/azurepolicy.json
+++ b/policyDefinitions/Authorization/deny-custom-roles-with-exclusionlist/azurepolicy.json
@@ -1,0 +1,57 @@
+{
+  "name": "4eaae358-7df4-4338-ae26-c4547ebe9403",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Custom roles are not allowed, except excluded role definition names",
+    "description": "This policy will audit or deny the creation of RBAC custom roles, excluding specified role definition names.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Authorization"
+    },
+    "mode": "All",
+    "parameters": {
+      "effect": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Deny, Audit or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "Deny",
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      },
+      "excludedRoleNames": {
+        "type": "array",
+        "metadata": {
+          "displayName": "Excluded Role Names",
+          "description": "Names of Roles to be excluded from the policy."
+        },
+        "defaultValue": []
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Authorization/roleDefinitions"
+          },
+          {
+            "field": "Microsoft.Authorization/roleDefinitions/type",
+            "notEquals": "BuiltInRole"
+          },
+          {
+            "field": "Microsoft.Authorization/roleDefinitions/roleName",
+            "notIn": "[parameters('ExcludedRoleNames')]"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/policyDefinitions/Authorization/deny-custom-roles-with-exclusionlist/azurepolicy.json
+++ b/policyDefinitions/Authorization/deny-custom-roles-with-exclusionlist/azurepolicy.json
@@ -10,6 +10,14 @@
     },
     "mode": "All",
     "parameters": {
+      "excludedRoleNames": {
+        "type": "array",
+        "metadata": {
+          "displayName": "Excluded Role Names",
+          "description": "Names of Roles to be excluded from the policy."
+        },
+        "defaultValue": []
+      },
       "effect": {
         "type": "string",
         "metadata": {
@@ -22,14 +30,6 @@
           "Disabled"
         ],
         "defaultValue": "Audit"
-      },
-      "excludedRoleNames": {
-        "type": "array",
-        "metadata": {
-          "displayName": "Excluded Role Names",
-          "description": "Names of Roles to be excluded from the policy."
-        },
-        "defaultValue": []
       }
     },
     "policyRule": {

--- a/policyDefinitions/Authorization/deny-custom-roles-with-exclusionlist/azurepolicy.json
+++ b/policyDefinitions/Authorization/deny-custom-roles-with-exclusionlist/azurepolicy.json
@@ -2,7 +2,7 @@
   "name": "4eaae358-7df4-4338-ae26-c4547ebe9403",
   "type": "Microsoft.Authorization/policyDefinitions",
   "properties": {
-    "displayName": "Custom roles are not allowed, except excluded role definition names",
+    "displayName": "Deny custom roles with exclusionlist",
     "description": "This policy will audit or deny the creation of RBAC custom roles, excluding specified role definition names.",
     "metadata": {
       "version": "1.0.0",

--- a/policyDefinitions/Authorization/deny-custom-roles-with-exclusionlist/azurepolicy.parameters.json
+++ b/policyDefinitions/Authorization/deny-custom-roles-with-exclusionlist/azurepolicy.parameters.json
@@ -1,4 +1,12 @@
 {
+    "excludedRoleNames": {
+        "type": "array",
+        "metadata": {
+            "displayName": "Excluded Role Names",
+            "description": "Names of Roles to be excluded from the policy."
+        },
+        "defaultValue": []
+    },
     "effect": {
         "type": "string",
         "metadata": {
@@ -11,13 +19,5 @@
             "Disabled"
         ],
         "defaultValue": "Audit"
-    },
-    "excludedRoleNames": {
-        "type": "array",
-        "metadata": {
-            "displayName": "Excluded Role Names",
-            "description": "Names of Roles to be excluded from the policy."
-        },
-        "defaultValue": []
     }
 }

--- a/policyDefinitions/Authorization/deny-custom-roles-with-exclusionlist/azurepolicy.parameters.json
+++ b/policyDefinitions/Authorization/deny-custom-roles-with-exclusionlist/azurepolicy.parameters.json
@@ -1,0 +1,23 @@
+{
+    "effect": {
+        "type": "string",
+        "metadata": {
+            "displayName": "Effect",
+            "description": "Deny, Audit or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+            "Deny",
+            "Audit",
+            "Disabled"
+        ],
+        "defaultValue": "Audit"
+    },
+    "excludedRoleNames": {
+        "type": "array",
+        "metadata": {
+            "displayName": "Excluded Role Names",
+            "description": "Names of Roles to be excluded from the policy."
+        },
+        "defaultValue": []
+    }
+}

--- a/policyDefinitions/Authorization/deny-custom-roles-with-exclusionlist/azurepolicy.rules.json
+++ b/policyDefinitions/Authorization/deny-custom-roles-with-exclusionlist/azurepolicy.rules.json
@@ -1,0 +1,21 @@
+{
+    "if": {
+        "allOf": [
+            {
+                "field": "type",
+                "equals": "Microsoft.Authorization/roleDefinitions"
+            },
+            {
+                "field": "Microsoft.Authorization/roleDefinitions/type",
+                "notEquals": "BuiltInRole"
+            },
+            {
+                "field": "Microsoft.Authorization/roleDefinitions/roleName",
+                "notIn": "[parameters('ExcludedRoleNames')]"
+            }
+        ]
+    },
+    "then": {
+        "effect": "[parameters('effect')]"
+    }
+}


### PR DESCRIPTION
Adding a new Azure Policy Defintion to support the possibility to audit/deny Custom Roles with an exclusion list.