### PR TITLE
Add policy for auditing Storage Accounts having configured firewall r…

### DIFF
--- a/policyDefinitions/Storage/audit-storageaccounts-having-configured-firewall-rules/azurepolicy.json
+++ b/policyDefinitions/Storage/audit-storageaccounts-having-configured-firewall-rules/azurepolicy.json
@@ -43,8 +43,12 @@
           },
           {
             "not": {
-              "field": "Microsoft.Storage/storageAccounts/networkAcls.ipRules[*].value",
-              "in": "[parameters('allowedAddressRanges')]"
+              "anyOf": [
+                {
+                  "field": "Microsoft.Storage/storageAccounts/networkAcls.ipRules[*].value",
+                  "in": "[parameters('allowedAddressRanges')]"
+                }
+              ]
             }
           }
         ]

--- a/policyDefinitions/Storage/audit-storageaccounts-having-configured-firewall-rules/azurepolicy.json
+++ b/policyDefinitions/Storage/audit-storageaccounts-having-configured-firewall-rules/azurepolicy.json
@@ -1,0 +1,57 @@
+{
+  "name": "537cd074-8c79-48c3-b896-d73c72ea7a12",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Audit Storage Accounts having configured firewall rules",
+    "description": "This policy audits storage accounts that are configured with unknown IP-addresses.",
+    "metadata": {
+      "category": "Storage",
+      "version": "1.0.0"
+    },
+    "mode": "All",
+    "parameters": {
+      "allowedAddressRanges": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Allowed IP addresses",
+          "description": "Add IP-addresses using the format x.x.x.x or x.x.x.x/xx"
+        }
+      },
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Audit or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Storage/storageAccounts"
+          },
+          {
+            "field": "Microsoft.Storage/storageAccounts/networkAcls.ipRules[*].value",
+            "notEquals": ""
+          },
+          {
+            "not": {
+              "field": "Microsoft.Storage/storageAccounts/networkAcls.ipRules[*].value",
+              "in": "[parameters('allowedAddressRanges')]"
+            }
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/policyDefinitions/Storage/audit-storageaccounts-having-configured-firewall-rules/azurepolicy.parameters.json
+++ b/policyDefinitions/Storage/audit-storageaccounts-having-configured-firewall-rules/azurepolicy.parameters.json
@@ -1,0 +1,21 @@
+{
+  "allowedAddressRanges": {
+    "type": "Array",
+    "metadata": {
+      "displayName": "Allowed IP addresses",
+      "description": "Add IP-addresses using the format x.x.x.x or x.x.x.x/xx"
+    }
+  },
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Audit or Disabled the execution of the Policy"
+    },
+    "allowedValues": [
+      "Audit",
+      "Disabled"
+    ],
+    "defaultValue": "Audit"
+  }
+}

--- a/policyDefinitions/Storage/audit-storageaccounts-having-configured-firewall-rules/azurepolicy.rules.json
+++ b/policyDefinitions/Storage/audit-storageaccounts-having-configured-firewall-rules/azurepolicy.rules.json
@@ -11,8 +11,12 @@
       },
       {
         "not": {
-          "field": "Microsoft.Storage/storageAccounts/networkAcls.ipRules[*].value",
-          "in": "[parameters('allowedAddressRanges')]"
+          "anyOf": [
+            {
+              "field": "Microsoft.Storage/storageAccounts/networkAcls.ipRules[*].value",
+              "in": "[parameters('allowedAddressRanges')]"
+            }
+          ]
         }
       }
     ]

--- a/policyDefinitions/Storage/audit-storageaccounts-having-configured-firewall-rules/azurepolicy.rules.json
+++ b/policyDefinitions/Storage/audit-storageaccounts-having-configured-firewall-rules/azurepolicy.rules.json
@@ -1,0 +1,23 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Storage/storageAccounts"
+      },
+      {
+        "field": "Microsoft.Storage/storageAccounts/networkAcls.ipRules[*].value",
+        "notEquals": ""
+      },
+      {
+        "not": {
+          "field": "Microsoft.Storage/storageAccounts/networkAcls.ipRules[*].value",
+          "in": "[parameters('allowedAddressRanges')]"
+        }
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}


### PR DESCRIPTION
It is often possible to add your ip address to the firewall on storage accounts but it is easy to forget to remove the ip address after the work is done.  The result can be 100+ firewall openings over many years. Furthermore, it can be hard to easily audit and follow up and that is what this policy aim to support.