### PR TITLE
Add deploy-qualys-agent-to-windows-vms policy that deploy BYOL Qualys agent to Windows VMs

### DIFF
--- a/policyDefinitions/Compute/deploy-qualys-agent-to-windows-vms/azurepolicy.json
+++ b/policyDefinitions/Compute/deploy-qualys-agent-to-windows-vms/azurepolicy.json
@@ -1,0 +1,330 @@
+{
+  "properties": {
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "name": "f926c206-3ea7-434c-9613-252390995744",
+    "displayName": "Deploy Qualys Agent on Windows Virtual Machine",
+    "mode": "Indexed",
+    "description": "This policy ensures that every Windows-based Azure Virtual Machine has the Qualys Agent extension installed. If the Qualys Agent is not present, the policy will automatically deploy it based on the specified parameters.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Compute"
+    },
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Define the enforcement action for non-compliant VMs."
+        },
+        "allowedValues": [
+          "DeployIfNotExists",
+          "Disabled"
+        ],
+        "defaultValue": "DeployIfNotExists"
+      },
+      "autoUpgradeMinorVersion": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Auto Upgrade Minor Version",
+          "description": "Enable or disable automatic minor version upgrades of the Qualys Agent extension."
+        },
+        "allowedValues": [
+          "true",
+          "false"
+        ],
+        "defaultValue": "false"
+      },
+      "LicenseCode": {
+        "type": "String",
+        "metadata": {
+          "displayName": "License Code",
+          "description": "The license code required for the Qualys Agent."
+        }
+      },
+      "listOfWindowsImageIdToInclude": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Additional Virtual Machine Images",
+          "description": "List of virtual machine images that have supported Windows OS to add to scope. Example values: '/subscriptions/<subscriptionId>/resourceGroups/YourResourceGroup/providers/Microsoft.Compute/images/ContosoStdImage'"
+        },
+        "defaultValue": []
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Compute/virtualMachines"
+          },
+          {
+            "anyOf": [
+              {
+                "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
+                "like": "Windows*"
+              },
+              {
+                "field": "Microsoft.Compute/imageId",
+                "in": "[parameters('listOfWindowsImageIdToInclude')]"
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "equals": "MicrosoftWindowsServer"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "equals": "WindowsServer"
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "field": "Microsoft.Compute/imageSku",
+                        "like": "2008-R2-SP1*"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSku",
+                        "like": "2012-*"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSku",
+                        "like": "2016-*"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSku",
+                        "like": "2019-*"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSku",
+                        "like": "2022-*"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "equals": "MicrosoftWindowsServer"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "equals": "WindowsServerSemiAnnual"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageSKU",
+                    "in": [
+                      "Datacenter-Core-1709-smalldisk",
+                      "Datacenter-Core-1709-with-Containers-smalldisk",
+                      "Datacenter-Core-1803-with-Containers-smalldisk"
+                    ]
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "equals": "MicrosoftWindowsServerHPCPack"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "equals": "WindowsServerHPCPack"
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "equals": "MicrosoftSQLServer"
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2022"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2022-BYOL"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2019"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2019-BYOL"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2016"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2016-BYOL"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2012R2"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "like": "*-WS2012R2-BYOL"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "equals": "MicrosoftRServer"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "equals": "MLServer-WS2016"
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "equals": "MicrosoftVisualStudio"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "in": [
+                      "VisualStudio",
+                      "Windows"
+                    ]
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "equals": "MicrosoftDynamicsAX"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "equals": "Dynamics"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageSKU",
+                    "equals": "Pre-Req-AX7-Onebox-U8"
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "equals": "microsoft-ads"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "equals": "windows-data-science-vm"
+                  }
+                ]
+              },
+              {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "equals": "MicrosoftWindowsDesktop"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "like": "Windows-1*"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "type": "Microsoft.Compute/virtualMachines/extensions",
+          "existenceCondition": {
+            "allOf": [
+              {
+                "field": "Microsoft.Compute/virtualMachines/extensions/type",
+                "equals": "QualysAgent"
+              },
+              {
+                "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+                "equals": "Qualys"
+              }
+            ]
+          },
+          "deployment": {
+            "properties": {
+              "mode": "Incremental",
+              "template": {
+                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {
+                  "vmName": {
+                    "type": "string"
+                  },
+                  "vmLocation": {
+                    "type": "string"
+                  },
+                  "LicenseCode": {
+                    "type": "string"
+                  },
+                  "autoUpgradeMinorVersion": {
+                    "type": "string"
+                  }
+                },
+                "resources": [
+                  {
+                    "name": "[concat(parameters('vmName'), '/QualysAgent')]",
+                    "type": "Microsoft.Compute/virtualMachines/extensions",
+                    "location": "[parameters('vmLocation')]",
+                    "apiVersion": "2015-06-15",
+                    "properties": {
+                      "publisher": "Qualys",
+                      "type": "QualysAgent",
+                      "typeHandlerVersion": "1.6",
+                      "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
+                      "settings": {
+                        "LicenseCode": "[parameters('LicenseCode')]"
+                      }
+                    }
+                  }
+                ]
+              },
+              "parameters": {
+                "vmName": {
+                  "value": "[field('name')]"
+                },
+                "vmLocation": {
+                  "value": "[field('location')]"
+                },
+                "LicenseCode": {
+                  "value": "[parameters('LicenseCode')]"
+                },
+                "autoUpgradeMinorVersion": {
+                  "value": "[parameters('autoUpgradeMinorVersion')]"
+                }
+              }
+            }
+          },
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/Compute/deploy-qualys-agent-to-windows-vms/azurepolicy.json
+++ b/policyDefinitions/Compute/deploy-qualys-agent-to-windows-vms/azurepolicy.json
@@ -1,7 +1,7 @@
 {
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "name": "f926c206-3ea7-434c-9613-252390995744",
   "properties": {
-    "type": "Microsoft.Authorization/policyDefinitions",
-    "name": "f926c206-3ea7-434c-9613-252390995744",
     "displayName": "Deploy Qualys Agent on Windows Virtual Machine",
     "mode": "Indexed",
     "description": "This policy ensures that every Windows-based Azure Virtual Machine has the Qualys Agent extension installed. If the Qualys Agent is not present, the policy will automatically deploy it based on the specified parameters.",

--- a/policyDefinitions/Compute/deploy-qualys-agent-to-windows-vms/azurepolicy.parameters.json
+++ b/policyDefinitions/Compute/deploy-qualys-agent-to-windows-vms/azurepolicy.parameters.json
@@ -1,0 +1,41 @@
+{
+    "effect": {
+      "type": "string",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Define the enforcement action for non-compliant VMs."
+      },
+      "allowedValues": [
+        "DeployIfNotExists",
+        "Disabled"
+      ],
+      "defaultValue": "DeployIfNotExists"
+    },
+    "autoUpgradeMinorVersion": {
+      "type": "string",
+      "metadata": {
+        "displayName": "Auto Upgrade Minor Version",
+        "description": "Enable or disable automatic minor version upgrades of the Qualys Agent extension."
+      },
+      "allowedValues": [
+        "true",
+        "false"
+      ],
+      "defaultValue": "false"
+    },
+    "LicenseCode": {
+      "type": "string",
+      "metadata": {
+        "displayName": "License Code",
+        "description": "The license code required for the Qualys Agent."
+      }
+    },
+    "listOfWindowsImageIdToInclude": {
+      "type": "array",
+      "metadata": {
+        "displayName": "Additional Virtual Machine Images",
+        "description": "List of virtual machine images that have supported Windows OS to add to scope. Example values: '/subscriptions/<subscriptionId>/resourceGroups/YourResourceGroup/providers/Microsoft.Compute/images/ContosoStdImage'"
+      },
+      "defaultValue": []
+    }
+  }

--- a/policyDefinitions/Compute/deploy-qualys-agent-to-windows-vms/azurepolicy.rules.json
+++ b/policyDefinitions/Compute/deploy-qualys-agent-to-windows-vms/azurepolicy.rules.json
@@ -1,0 +1,276 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Compute/virtualMachines"
+      },
+      {
+        "anyOf": [
+          {
+            "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
+            "like": "Windows*"
+          },
+          {
+            "field": "Microsoft.Compute/imageId",
+            "in": "[parameters('listOfWindowsImageIdToInclude')]"
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Compute/imagePublisher",
+                "equals": "MicrosoftWindowsServer"
+              },
+              {
+                "field": "Microsoft.Compute/imageOffer",
+                "equals": "WindowsServer"
+              },
+              {
+                "anyOf": [
+                  {
+                    "field": "Microsoft.Compute/imageSku",
+                    "like": "2008-R2-SP1*"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageSku",
+                    "like": "2012-*"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageSku",
+                    "like": "2016-*"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageSku",
+                    "like": "2019-*"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageSku",
+                    "like": "2022-*"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Compute/imagePublisher",
+                "equals": "MicrosoftWindowsServer"
+              },
+              {
+                "field": "Microsoft.Compute/imageOffer",
+                "equals": "WindowsServerSemiAnnual"
+              },
+              {
+                "field": "Microsoft.Compute/imageSKU",
+                "in": [
+                  "Datacenter-Core-1709-smalldisk",
+                  "Datacenter-Core-1709-with-Containers-smalldisk",
+                  "Datacenter-Core-1803-with-Containers-smalldisk"
+                ]
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Compute/imagePublisher",
+                "equals": "MicrosoftWindowsServerHPCPack"
+              },
+              {
+                "field": "Microsoft.Compute/imageOffer",
+                "equals": "WindowsServerHPCPack"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Compute/imagePublisher",
+                "equals": "MicrosoftSQLServer"
+              },
+              {
+                "anyOf": [
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "like": "*-WS2022"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "like": "*-WS2022-BYOL"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "like": "*-WS2019"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "like": "*-WS2019-BYOL"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "like": "*-WS2016"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "like": "*-WS2016-BYOL"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "like": "*-WS2012R2"
+                  },
+                  {
+                    "field": "Microsoft.Compute/imageOffer",
+                    "like": "*-WS2012R2-BYOL"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Compute/imagePublisher",
+                "equals": "MicrosoftRServer"
+              },
+              {
+                "field": "Microsoft.Compute/imageOffer",
+                "equals": "MLServer-WS2016"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Compute/imagePublisher",
+                "equals": "MicrosoftVisualStudio"
+              },
+              {
+                "field": "Microsoft.Compute/imageOffer",
+                "in": [
+                  "VisualStudio",
+                  "Windows"
+                ]
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Compute/imagePublisher",
+                "equals": "MicrosoftDynamicsAX"
+              },
+              {
+                "field": "Microsoft.Compute/imageOffer",
+                "equals": "Dynamics"
+              },
+              {
+                "field": "Microsoft.Compute/imageSKU",
+                "equals": "Pre-Req-AX7-Onebox-U8"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Compute/imagePublisher",
+                "equals": "microsoft-ads"
+              },
+              {
+                "field": "Microsoft.Compute/imageOffer",
+                "equals": "windows-data-science-vm"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "field": "Microsoft.Compute/imagePublisher",
+                "equals": "MicrosoftWindowsDesktop"
+              },
+              {
+                "field": "Microsoft.Compute/imageOffer",
+                "like": "Windows-1*"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "existenceCondition": {
+        "allOf": [
+          {
+            "field": "Microsoft.Compute/virtualMachines/extensions/type",
+            "equals": "QualysAgent"
+          },
+          {
+            "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+            "equals": "Qualys"
+          }
+        ]
+      },
+      "deployment": {
+        "properties": {
+          "mode": "Incremental",
+          "template": {
+            "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "vmName": {
+                "type": "string"
+              },
+              "vmLocation": {
+                "type": "string"
+              },
+              "LicenseCode": {
+                "type": "string"
+              },
+              "autoUpgradeMinorVersion": {
+                "type": "string"
+              }
+            },
+            "resources": [
+              {
+                "name": "[concat(parameters('vmName'), '/QualysAgent')]",
+                "type": "Microsoft.Compute/virtualMachines/extensions",
+                "location": "[parameters('vmLocation')]",
+                "apiVersion": "2015-06-15",
+                "properties": {
+                  "publisher": "Qualys",
+                  "type": "QualysAgent",
+                  "typeHandlerVersion": "1.6",
+                  "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
+                  "settings": {
+                    "LicenseCode": "[parameters('LicenseCode')]"
+                  }
+                }
+              }
+            ]
+          },
+          "parameters": {
+            "vmName": {
+              "value": "[field('name')]"
+            },
+            "vmLocation": {
+              "value": "[field('location')]"
+            },
+            "LicenseCode": {
+              "value": "[parameters('LicenseCode')]"
+            },
+            "autoUpgradeMinorVersion": {
+              "value": "[parameters('autoUpgradeMinorVersion')]"
+            }
+          }
+        }
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The Microsoft Defender for Cloud Enable vulnerability scanning with the integrated Qualys scanner has been deprecated. So, I created this policy to deploy the Qualys Agent (BYOL) on Windows VMs.