### PR TITLE
Unique ID GitHub Action - parsing failure fix and wording update

### DIFF
--- a/.github/workflows/confirm-policy-definition-no-built-in-conflicts.yaml
+++ b/.github/workflows/confirm-policy-definition-no-built-in-conflicts.yaml
@@ -183,11 +183,11 @@ jobs:
               echo '   \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/////////////////////////////////'
               echo '   |                                                                |'
               echo '   |                   -   VALIDATION FAILED   -                    |'
-              echo '   | Policy name exists as another existing Azure Policy Definition |'
+              echo '   |     Policy name exists as another Azure Policy Definition      |'
               echo '   |                                                                |'
               echo '   \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/////////////////////////////////'
               echo ""
-              echo "   This pull request: ${policyName} == existing definition: $(echo $filteredResponse | jq -r '.n')"
+              echo "   This pull request's name: ${policyName} == existing definition name: $(echo $filteredResponse | jq -r '.n')"
               echo ""
               echo '   Conflicting Policy Definition Details:'
               echo "      Name: $(echo $filteredResponse | jq -r '.n')"

--- a/.github/workflows/confirm-policy-definition-no-built-in-conflicts.yaml
+++ b/.github/workflows/confirm-policy-definition-no-built-in-conflicts.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - fix-file-read-error
 
 jobs:
   # -------------------------------------------------------------

--- a/.github/workflows/confirm-policy-definition-no-built-in-conflicts.yaml
+++ b/.github/workflows/confirm-policy-definition-no-built-in-conflicts.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - fix-file-read-error
 
 jobs:
   # -------------------------------------------------------------
@@ -156,7 +157,7 @@ jobs:
             
             echo 'Step 3: Sending request to AzAdvertizer API to search for Policy Name in existing resources.'
 
-            response=$(curl -s "https://www.azadvertizer.net/AzPolicyAdvertizerRuleThemAllData.json")
+            response=$(curl -s --compressed "https://www.azadvertizer.net/AzPolicyAdvertizerRuleThemAllData.json")
             
             if [ -z "$response" ]; then
               echo '   Error: API Response - No response from AzAdvertizer.'
@@ -183,7 +184,7 @@ jobs:
               echo '   \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/////////////////////////////////'
               echo '   |                                                                |'
               echo '   |                   -   VALIDATION FAILED   -                    |'
-              echo '   |    Policy name exists as a Built-In Azure Policy Definition    |'
+              echo '   | Policy name exists as another existing Azure Policy Definition |'
               echo '   |                                                                |'
               echo '   \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/////////////////////////////////'
               echo ""

--- a/.github/workflows/confirm-policy-definition-no-built-in-conflicts.yaml
+++ b/.github/workflows/confirm-policy-definition-no-built-in-conflicts.yaml
@@ -213,12 +213,12 @@ jobs:
               echo ""
               exit 1
             else
-              echo '   Success: GUID not found in Built-In Azure Policy Repo.'
+              echo '   Success: GUID not found in Built-In or Community Azure Policy Repo.'
               echo '   \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/////////////////////////////////'
               echo '   |                                                                |'
               echo '   |                  -   VALIDATION SUCCESS   -                    |'
               echo '   |                  Policy name is a valid GUID                   |'
-              echo '   |     and does not match existing built-in Policy Definition     |'
+              echo '   |        and does not match an existing Policy Definition        |'
               echo '   |                                                                |'
               echo '   \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/////////////////////////////////'
               exit 0

--- a/.github/workflows/confirm-policy-definition-no-built-in-conflicts.yaml
+++ b/.github/workflows/confirm-policy-definition-no-built-in-conflicts.yaml
@@ -188,22 +188,26 @@ jobs:
               echo '   |                                                                |'
               echo '   \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/////////////////////////////////'
               echo ""
-              echo "   This: ${policyName} == built-in: $(echo $filteredResponse | jq -r '.n')"
+              echo "   This pull request: ${policyName} == existing definition: $(echo $filteredResponse | jq -r '.n')"
               echo ""
-              echo '   Conflicting Built-In Policy Definition Details:'
+              echo '   Conflicting Policy Definition Details:'
               echo "      Name: $(echo $filteredResponse | jq -r '.n')"
               echo "      Display Name: $(echo $filteredResponse | jq -r '.def' | jq -r '.displayName')"
               echo "      Description: $(echo $filteredResponse | jq -r '.def' | jq -r '.description')"
               echo ""
               echo '   \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/////////////////////////////////'
-              echo '   |                                                                |'
-              echo '   |                       -   NEXT STEPS   -                       |'
-              echo '   |         Please change the policy name to a unique GUID         |'
-              echo '   |  Please do not submit only slightly altered built-in policies  |'
-              echo '   |                                                                |'
-              echo '   |     What is a GUID? https://www.rfc-editor.org/rfc/rfc4122     |'
-              echo '   |     Make a new GUID in PowerShell: https://aka.ms/new-guid     |'
-              echo '   |                                                                |'
+              echo '   |                                                                 |'
+              echo '   |                       -   NEXT STEPS   -                        |'
+              echo '   |         Please change the policy name to a unique GUID          |'
+              echo '   |  Please do not submit only slightly altered built-in policies   |'
+              echo '   |                                                                 |'
+              echo '   |                      ----   NOTE   ----                         |'
+              echo '   | If you are intentionally updating an existing Community Policy  |'
+              echo '   | Azure Policy Definition, then this check failure can be ignored |'
+              echo '   |                                                                 |'
+              echo '   |     What is a GUID? https://www.rfc-editor.org/rfc/rfc4122      |'
+              echo '   |     Make a new GUID in PowerShell: https://aka.ms/new-guid      |'
+              echo '   |                                                                 |'
               echo '   \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/////////////////////////////////'
               echo ""
               echo ""

--- a/Policies/Storage/enforce-or-extend-storage-account-iprules-if-tag-match/azurepolicy.json
+++ b/Policies/Storage/enforce-or-extend-storage-account-iprules-if-tag-match/azurepolicy.json
@@ -1,7 +1,7 @@
 {
     "name": "7e5e7a22-32fe-4537-aca8-786a5f871e13",
     "properties": {
-        "displayName": "Enforce or extend Storage Account IPRules if tag match ",
+        "displayName": "Enforce or extend Storage Account IPRules if tag match",
         "description": "This policy enforces or extends IP ranges if the Storage Account has a matching tag/value (deviating existing IP ranges may be kept or overwritten (parameter: existingIPRangesHandling)). 'publicNetworkAccess' will be enabled if disabled.",
         "mode": "Indexed",
         "metadata": {

--- a/Policies/Storage/enforce-or-extend-storage-account-iprules-if-tag-match/azurepolicy.json
+++ b/Policies/Storage/enforce-or-extend-storage-account-iprules-if-tag-match/azurepolicy.json
@@ -1,7 +1,7 @@
 {
     "name": "7e5e7a22-32fe-4537-aca8-786a5f871e13",
     "properties": {
-        "displayName": "Enforce or extend Storage Account IPRules if tag match",
+        "displayName": "Enforce or extend Storage Account IPRules if tag match ",
         "description": "This policy enforces or extends IP ranges if the Storage Account has a matching tag/value (deviating existing IP ranges may be kept or overwritten (parameter: existingIPRangesHandling)). 'publicNetworkAccess' will be enabled if disabled.",
         "mode": "Indexed",
         "metadata": {


### PR DESCRIPTION
#491 
Root Cause:
I was able to find the source file we are getting from https://www.azadvertizer.net is now large enough that it is being compressed to binary and therefore was failing to be parsed by the JSON parser in bash.

Solution:
Added the --compressed flag to the curl request to handle the compression of the file.

Extra Testing:
Validated the --compressed flag in curl would not throw an error when downloading an uncompressed file so this should not be a breaking change if we start receiving an uncompressed response from azadvertizer.net again. 

#477 
While in the code I also added the wording improvements to this script to remove the direct references to built-in definitions and to keep the responses more generic / inclusive of the fact that we can also match community policies with this data source. 