### PR TITLE
New Policy: Deny Fabric Capacity Creation

### DIFF
--- a/policyDefinitions/General/deny-fabric-capacity-creation/azurepolicy.json
+++ b/policyDefinitions/General/deny-fabric-capacity-creation/azurepolicy.json
@@ -1,0 +1,37 @@
+{
+    "name": "f20fb0b9-f5bb-4a0d-ab8f-f9c28bf16746",
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "properties": {
+      "displayName": "Deny Fabric Capacity creations",
+      "description": "This policy prevents or audits the creation of fabric capacity resources to enhance governance whenever needed",
+      "metadata": {
+        "category": "General",
+        "version": "1.0.0"
+      },
+      "mode": "all",
+      "parameters": {
+        "effect": {
+          "type": "String",
+          "metadata": {
+            "displayName": "Effect",
+            "description": "Deny, Audit or Disabled the execution of the Policy"
+          },
+          "allowedValues": [
+            "Deny",
+            "Audit",
+            "Disabled"
+          ],
+          "defaultValue": "Audit"
+        }
+      },
+      "policyRule": {
+        "if": {
+          "field": "type",
+          "like": "Microsoft.Fabric/capacities*"
+        },
+        "then": {
+          "effect": "[parameters('effect')]"
+        }
+      }
+    }
+  }

--- a/policyDefinitions/General/deny-fabric-capacity-creation/azurepolicy.parameters.json
+++ b/policyDefinitions/General/deny-fabric-capacity-creation/azurepolicy.parameters.json
@@ -1,0 +1,16 @@
+{
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Deny, Audit or Disabled the execution of the Policy"
+      },
+      "allowedValues": [
+        "Deny",
+        "Audit",
+        "Disabled"
+      ],
+      "defaultValue": "Audit"
+    }
+  }
+  

--- a/policyDefinitions/General/deny-fabric-capacity-creation/azurepolicy.rules.json
+++ b/policyDefinitions/General/deny-fabric-capacity-creation/azurepolicy.rules.json
@@ -1,0 +1,10 @@
+{
+    "if": {
+      "field": "type",
+      "like": "Microsoft.Fabric/capacities*"
+    },
+    "then": {
+      "effect": "[parameters('effect')]"
+    }
+  }
+  


### PR DESCRIPTION
This PR introduces a simple "Deny-Resource" policy focused on Fabric Capacities. 
The policy is required for organisations which wants to govern the usage of Fabric within their own ecosystem, due to the implementation of capacities. 

The General category has been used as a catch-all, seeing as Fabric does not have a more specific one. 

# Manual validation & tests

The following scenarios has been tested. 

- [x] `Out-FormattedPolicyDefinition.ps1` returns valid
- [x] Tested with new resource creation (blocked)
- [x] Tested with existing resource changes (allowed)