### PR TITLE
removing incorrect character from the deployment template

### DIFF
--- a/policyDefinitions/Storage/enforce-or-extend-storage-account-iprules-if-tag-match/azurepolicy.json
+++ b/policyDefinitions/Storage/enforce-or-extend-storage-account-iprules-if-tag-match/azurepolicy.json
@@ -117,7 +117,7 @@
             "properties": {
               "mode": "Incremental",
               "template": {
-                "`$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
                 "contentVersion": "1.0.0.0",
                 "parameters": {
                   "resourceName": {

--- a/policyDefinitions/Storage/enforce-or-extend-storage-account-iprules-if-tag-match/azurepolicy.rules.json
+++ b/policyDefinitions/Storage/enforce-or-extend-storage-account-iprules-if-tag-match/azurepolicy.rules.json
@@ -54,7 +54,7 @@
         "properties": {
           "mode": "Incremental",
           "template": {
-            "`$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
             "contentVersion": "1.0.0.0",
             "parameters": {
               "resourceName": {


### PR DESCRIPTION
removing incorrect character from the deployment template
the remediation has been tested and works on greenfield and brownfield