### PR TITLE
New Policy Def: Deny Log Analytics Workspace without Daily Quota

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,0 @@
-{
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
-  "features": {
-    "ghcr.io/devcontainers/features/powershell:1.5.0": {}
-}
-}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/powershell:1.5.0": {}
+}
+}

--- a/policyDefinitions/Monitoring/log-analytics-workspace-require-daily-quota/azurepolicy.json
+++ b/policyDefinitions/Monitoring/log-analytics-workspace-require-daily-quota/azurepolicy.json
@@ -1,0 +1,45 @@
+{
+  "name": "a8da5dfa-4bb2-46aa-bd3f-5be6bcf2681b",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Deny creation of Log Analytics workspace without daily quota",
+    "description": "This policy denies the creation of Log Analytics workspaces if the daily quota is not set.",
+    "metadata": {
+      "category": "Log Analytics",
+      "version": "1.0.0"
+    },
+    "mode": "all",
+    "parameters": {
+      "effect": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Deny, Audit or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "Deny",
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Deny"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.OperationalInsights/workspaces"
+          },
+          {
+            "field": "Microsoft.OperationalInsights/workspaces/workspaceCapping.dailyQuotaGb",
+            "exists": false
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/policyDefinitions/Monitoring/log-analytics-workspace-require-daily-quota/azurepolicy.json
+++ b/policyDefinitions/Monitoring/log-analytics-workspace-require-daily-quota/azurepolicy.json
@@ -5,7 +5,7 @@
     "displayName": "Deny creation of Log Analytics workspace without daily quota",
     "description": "This policy denies the creation of Log Analytics workspaces if the daily quota is not set.",
     "metadata": {
-      "category": "Log Analytics",
+      "category": "Monitoring",
       "version": "1.0.0"
     },
     "mode": "all",

--- a/policyDefinitions/Monitoring/log-analytics-workspace-require-daily-quota/azurepolicy.parameters.json
+++ b/policyDefinitions/Monitoring/log-analytics-workspace-require-daily-quota/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Deny, Audit or Disabled the execution of the Policy"
+    },
+    "allowedValues": [
+      "Deny",
+      "Audit",
+      "Disabled"
+    ],
+    "defaultValue": "Deny"
+  }
+}

--- a/policyDefinitions/Monitoring/log-analytics-workspace-require-daily-quota/azurepolicy.rules.json
+++ b/policyDefinitions/Monitoring/log-analytics-workspace-require-daily-quota/azurepolicy.rules.json
@@ -1,0 +1,17 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.OperationalInsights/workspaces"
+      },
+      {
+        "field": "Microsoft.OperationalInsights/workspaces/workspaceCapping.dailyQuotaGb",
+        "exists": false
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]"
+  }
+}


### PR DESCRIPTION
This PR introduces a new (custom) policy definition that will deny a log analytics workspace resource being created without a daily quota property being set.

Log Analytics category is not valid in the tests, therefore I have used 'Monitoring' to align to the existing LAW definition about retention.

<img width="772" alt="image" src="https://github.com/user-attachments/assets/6dda1676-3374-476a-a7eb-645f2e0c9273" />

![image](https://github.com/user-attachments/assets/b233aadd-0622-4f2d-a14e-5e9aad775493)

- [x]  [Out-FormattedPolicyDefinition.ps1 returns valid
- [x]  Tested with new resource creation (blocked)
- [x]  Tested with existing resource changes (allowed)