### PR TITLE
New definition "Allowed Private DNS Zones"

### DIFF
--- a/policyDefinitions/Network/allowed-pdns-zones/azurepolicy.json
+++ b/policyDefinitions/Network/allowed-pdns-zones/azurepolicy.json
@@ -4,7 +4,6 @@
   "properties": {
     "displayName": "Allowed Private DNS Zones",
     "description": "This policy restricts the creation of private DNS zones to a specified list.",
-    "policyType": "Custom",
     "mode": "Indexed",
     "metadata": {
       "version": "1.0.0",

--- a/policyDefinitions/Network/allowed-pdns-zones/azurepolicy.json
+++ b/policyDefinitions/Network/allowed-pdns-zones/azurepolicy.json
@@ -1,0 +1,55 @@
+{
+  "name": "b4028c7f-dace-44be-b194-6501ba609343",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Allowed Private DNS Zones",
+    "description": "This policy restricts the creation of private DNS zones to a specified list.",
+    "policyType": "Custom",
+    "mode": "Indexed",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Network"
+    },
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+            "Audit", 
+            "Deny", 
+            "Disabled"
+        ],
+        "defaultValue": "Deny"
+      },
+      "allowedPrivateDnsZones": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Allowed Private DNS Zones",
+          "description": "List of allowed private DNS zones. Any other zones will be denied."
+        }
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/privateDnsZones"
+          },
+          {
+            "not": {
+              "field": "name",
+              "in": "[parameters('allowedPrivateDnsZones')]"
+            }
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  }
+}

--- a/policyDefinitions/Network/allowed-pdns-zones/azurepolicy.parameters.json
+++ b/policyDefinitions/Network/allowed-pdns-zones/azurepolicy.parameters.json
@@ -1,0 +1,22 @@
+{
+    "effect": {
+        "type": "String",
+        "metadata": {
+        "displayName": "Effect",
+        "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+            "Audit", 
+            "Deny", 
+            "Disabled"
+        ],
+        "defaultValue": "Deny"
+    },
+    "allowedPrivateDnsZones": {
+        "type": "Array",
+        "metadata": {
+        "displayName": "Allowed Private DNS Zones",
+        "description": "List of allowed private DNS zones. Any other zones will be denied."
+        }
+    }
+}

--- a/policyDefinitions/Network/allowed-pdns-zones/azurepolicy.rules.json
+++ b/policyDefinitions/Network/allowed-pdns-zones/azurepolicy.rules.json
@@ -1,0 +1,19 @@
+{
+    "if": {
+      "allOf": [
+        {
+          "field": "type",
+          "equals": "Microsoft.Network/privateDnsZones"
+        },
+        {
+          "not": {
+            "field": "name",
+            "in": "[parameters('allowedPrivateDnsZones')]"
+          }
+        }
+      ]
+    },
+    "then": {
+      "effect": "[parameters('effect')]"
+    }
+}


### PR DESCRIPTION
I've added this new Policy definition to cater for the scenario where Private DNS zones are not allowed to be deployed, except for a set of excluded zones (e.g. AKS private DNS zone).

I validated the policy by attempting to create a PDNS zone that is not in the list (blocked) and one that was in the list (allowed). 