### PR TITLE
New Policy Def:  Enforce Enabling Private Endpoint Network Policy on subnets

### DIFF
--- a/policyDefinitions/Network/enforce-enabling-private-endpoint-network-policies-on-subnets/azurepolicy.json
+++ b/policyDefinitions/Network/enforce-enabling-private-endpoint-network-policies-on-subnets/azurepolicy.json
@@ -1,0 +1,71 @@
+{
+  "name": "d2f65624-c453-4423-bc8d-13204ff3f754",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Enforce Enabling-Private Endpoint Network Policies on Subnets",
+    "description": "This policy enables the privateEndpointNetworkPolicies for subnets with Modify effect.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Network"
+    },
+    "mode": "All",
+    "parameters": {
+      "privateEndpointNetworkPoliciesValue": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Private Endpoint Network Policies Value."
+        },
+        "allowedValues": [
+          "Enabled",
+          "NetworkSecurityGroupEnabled",
+          "RouteTableEnabled"
+        ],
+        "defaultValue": "Enabled"
+      },
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Modify, Deny, Audit or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "Modify",
+          "Deny",
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Modify"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/virtualNetworks/subnets"
+          },
+          {
+            "field": "Microsoft.Network/virtualNetworks/subnets/privateEndpointNetworkPolicies",
+            "notEquals": "[parameters('privateEndpointNetworkPoliciesValue')]"
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "roleDefinitionIds": [
+            "/providers/microsoft.authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+          ],
+          "conflictEffect": "audit",
+          "operations": [
+            {
+              "operation": "addOrReplace",
+              "field": "Microsoft.Network/virtualNetworks/subnets/privateEndpointNetworkPolicies",
+              "value": "[parameters('privateEndpointNetworkPoliciesValue')]"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/Network/enforce-enabling-private-endpoint-network-policies-on-subnets/azurepolicy.parameters.json
+++ b/policyDefinitions/Network/enforce-enabling-private-endpoint-network-policies-on-subnets/azurepolicy.parameters.json
@@ -1,0 +1,28 @@
+{
+  "privateEndpointNetworkPoliciesValue": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Private Endpoint Network Policies Value."
+    },
+    "allowedValues": [
+      "Enabled",
+      "NetworkSecurityGroupEnabled",
+      "RouteTableEnabled"
+    ],
+    "defaultValue": "Enabled"
+  },
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Modify, Deny, Audit or Disabled the execution of the Policy"
+    },
+    "allowedValues": [
+      "Modify",
+      "Deny",
+      "Audit",
+      "Disabled"
+    ],
+    "defaultValue": "Modify"
+  }
+}

--- a/policyDefinitions/Network/enforce-enabling-private-endpoint-network-policies-on-subnets/azurepolicy.rules.json
+++ b/policyDefinitions/Network/enforce-enabling-private-endpoint-network-policies-on-subnets/azurepolicy.rules.json
@@ -1,0 +1,30 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Network/virtualNetworks/subnets"
+      },
+      {
+        "field": "Microsoft.Network/virtualNetworks/subnets/privateEndpointNetworkPolicies",
+        "notEquals": "[parameters('privateEndpointNetworkPoliciesValue')]"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "roleDefinitionIds": [
+        "/providers/microsoft.authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+      ],
+      "conflictEffect": "audit",
+      "operations": [
+        {
+          "operation": "addOrReplace",
+          "field": "Microsoft.Network/virtualNetworks/subnets/privateEndpointNetworkPolicies",
+          "value": "[parameters('privateEndpointNetworkPoliciesValue')]"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a policy definition that enables the auto modification of network policies for private endpoints. My testing confirmed that when creating or updating subnet resources, the private endpoint network policy is modified with user selected parameters accordingly.

<Before create/update>
<img width="449" alt="image" src="https://github.com/user-attachments/assets/33b288c7-4178-4283-9f22-fb340fdab1f0" />
<After create/update>
<img width="364" alt="image" src="https://github.com/user-attachments/assets/0148ed0b-e633-4d04-ac68-b6fbd753d937" />


- [x] Confirm-PolicyDefinitionIsValid returns valid
- [x]  Tested with new resource creation (modified)
- [x]  Tested with existing resource changes  (modified)