### PR TITLE
Add policy to inherit tags from subscription to resource group

### DIFF
--- a/policyDefinitions/Tags/inherit-tag-from-subscription-to-resource-group/azurepolicy.json
+++ b/policyDefinitions/Tags/inherit-tag-from-subscription-to-resource-group/azurepolicy.json
@@ -1,0 +1,69 @@
+{
+  "name": "e7b1c2a9-4f3e-4c2a-9b2d-1a2b3c4d5e6f",
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "properties": {
+    "displayName": "Inherit Tag From Subscription To Resource Group",
+    "description": "Adds the specified tag with its value from the containing subscription when a resource group is missing this tag. Existing resource groups can be remediated by triggering a remediation task. If the tag exists with a different value it will not be changed.",
+    "metadata": {
+      "version": "1.0.0",
+      "category": "Tags"
+    },
+    "mode": "All",
+    "parameters": {
+      "tagName": {
+        "type": "String",
+        "metadata": {
+          "displayName": "tagName",
+          "description": "Name of the tag that should be inherited from the subscription, such as 'environment'"
+        }
+      },
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Modify, Deny, Audit or Disabled the execution of the Policy"
+        },
+        "allowedValues": [
+          "Modify",
+          "Deny",
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Modify"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Resources/subscriptions/resourceGroups"
+          },
+          {
+            "field": "[concat('tags[', parameters('tagName'), ']')]",
+            "exists": "false"
+          },
+          {
+            "value": "[subscription().tags[parameters('tagName')]]",
+            "notEquals": ""
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+          ],
+          "operations": [
+            {
+              "operation": "add",
+              "field": "[concat('tags[', parameters('tagName'), ']')]",
+              "value": "[subscription().tags[parameters('tagName')]]"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/Tags/inherit-tag-from-subscription-to-resource-group/azurepolicy.parameters.json
+++ b/policyDefinitions/Tags/inherit-tag-from-subscription-to-resource-group/azurepolicy.parameters.json
@@ -1,0 +1,23 @@
+{
+  "tagName": {
+    "type": "String",
+    "metadata": {
+      "displayName": "tagName",
+      "description": "Name of the tag that should be inherited from the subscription, such as 'environment'"
+    }
+  },
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Modify, Deny, Audit or Disabled the execution of the Policy"
+    },
+    "allowedValues": [
+      "Modify",
+      "Deny",
+      "Audit",
+      "Disabled"
+    ],
+    "defaultValue": "Modify"
+  }
+}

--- a/policyDefinitions/Tags/inherit-tag-from-subscription-to-resource-group/azurepolicy.rules.json
+++ b/policyDefinitions/Tags/inherit-tag-from-subscription-to-resource-group/azurepolicy.rules.json
@@ -1,0 +1,33 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Resources/subscriptions/resourceGroups"
+      },
+      {
+        "field": "[concat('tags[', parameters('tagName'), ']')]",
+        "exists": "false"
+      },
+      {
+        "value": "[subscription().tags[parameters('tagName')]]",
+        "notEquals": ""
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+      ],
+      "operations": [
+        {
+          "operation": "add",
+          "field": "[concat('tags[', parameters('tagName'), ']')]",
+          "value": "[subscription().tags[parameters('tagName')]]"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Introduce a policy definition that allows resource groups to inherit specified tags from their containing subscription when those tags are missing. 

Existing resource groups can be remediated through a task if necessary.

[x] Confirm-PolicyDefinitionIsValid returns valid
[x] Tested with new resource creation (modified)
[x] Tested with existing resource changes (modified)