### PR TITLE
Add Policy for configuring private dns zones on any private endpoint Improved - with compliance working 100%

### DIFF
--- a/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.json
+++ b/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.json
@@ -1,254 +1,264 @@
 {
-  "mode": "Indexed",
-  "policyRule": {
-    "if": {
-      "allOf": [
-        {
-          "field": "type",
-          "equals": "Microsoft.Network/privateEndpoints"
+    "name": "6f69622e-dbb3-4a41-92bf-071bc1be1752",
+    "type": "Microsoft.Authorization/policyDefinitions",
+    "properties": {
+        "displayName": "Configure Private Endpoint for PaaS services to use private DNS zones",
+        "description": "This policy will deploy Private DNS Zone Configs for any kind of Private Endpoint - With compliance working as it should and resolving the openAi - Foundry 3v1 dns problem",
+        "metadata": {
+            "version": "1.0.0",
+            "category": "Network"
         },
-        {
-          "count": {
-            "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
-            "where": {
-              "allOf": [
-                {
-                  "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
-                  "contains": "[parameters('privateEndpointPrivateLinkServiceId')]"
-                },
-                {
-                  "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
-                  "equals": "[parameters('privateEndpointGroupId')]"
-                }
-              ]
-            }
-          },
-          "greaterOrEquals": 1
-        }
-      ]
-    },
-    "then": {
-      "effect": "[parameters('effect')]",
-      "details": {
-        "type": "Microsoft.Network/privateEndpoints",
-        "evaluationDelay": "PT5M",
-        "name": "[field('name')]",
-        "existenceCondition": {
-          "allOf": [
-            {
-              "field": "Microsoft.Network/privateEndpoints/customDnsConfigs[*]",
-              "exists": true
-            },
-            {
-              "count": {
-                "field": "Microsoft.Network/privateEndpoints/customDnsConfigs[*]"
-              },
-              "equals": 0
-            }
-          ]
-        },
-        "roleDefinitionIds": [
-          "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
-        ],
-        "deployment": {
-          "properties": {
-            "mode": "incremental",
-            "parameters": {
-              "privateEndpointName": {
-                "value": "[field('name')]"
-              },
-              "privateEndpointId": {
-                "value": "[field('id')]"
-              },
-              "location": {
-                "value": "[field('location')]"
-              },
-              "dnsZoneGroupName": {
-                "value": "[parameters('dnsZoneGroupName')]"
-              },
-              "dnsConfigsRG": {
-                "value": "[parameters('dnsConfigsRG')]"
-              }
-            },
-            "template": {
-              "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-              "contentVersion": "1.0.0.0",
-              "parameters": {
-                "privateEndpointName": {
-                  "type": "string"
-                },
-                "privateEndpointId": {
-                  "type": "string"
-                },
-                "location": {
-                  "type": "string"
-                },
-                "dnsZoneGroupName": {
-                  "type": "string"
-                },
-                "dnsConfigsRG": {
-                  "type": "string"
-                }
-              },
-              "variables": {
-                "getPECurrentProperties": "[concat('getPECurrentProperties-', uniqueString(deployment().name))]",
-                "deployPEDNSConfigs": "[concat('deployPEDNSConfigs-', uniqueString(deployment().name))]"
-              },
-              "resources": [
-                {
-                  "type": "Microsoft.Resources/deployments",
-                  "apiVersion": "2020-06-01",
-                  "name": "[variables('getPECurrentProperties')]",
-                  "properties": {
-                    "expressionEvaluationOptions": {
-                      "scope": "inner"
+        "mode": "Indexed",
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Network/privateEndpoints"
                     },
-                    "mode": "Incremental",
-                    "parameters": {
-                      "privateEndpointId": {
-                        "value": "[parameters('privateEndpointId')]"
-                      }
-                    },
-                    "template": {
-                      "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                      "contentVersion": "1.0.0.0",
-                      "parameters": {
-                        "privateEndpointId": {
-                          "type": "string"
-                        }
-                      },
-                      "outputs": {
-                        "resource": {
-                          "type": "object",
-                          "value": "[reference(parameters('privateEndpointId'), '2024-10-01', 'Full')]"
-                        }
-                      },
-                      "resources": []
+                    {
+                        "count": {
+                            "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
+                            "where": {
+                                "allOf": [
+                                    {
+                                        "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+                                        "contains": "[parameters('privateEndpointPrivateLinkServiceId')]"
+                                    },
+                                    {
+                                        "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+                                        "equals": "[parameters('privateEndpointGroupId')]"
+                                    }
+                                ]
+                            }
+                        },
+                        "greaterOrEquals": 1
                     }
-                  }
-                },
-                {
-                  "type": "Microsoft.Resources/deployments",
-                  "apiVersion": "2020-06-01",
-                  "dependsOn": [
-                    "[variables('getPECurrentProperties')]"
-                  ],
-                  "name": "[variables('deployPEDNSConfigs')]",
-                  "properties": {
-                    "expressionEvaluationOptions": {
-                      "scope": "inner"
+                ]
+            },
+            "then": {
+                "effect": "[parameters('effect')]",
+                "details": {
+                    "type": "Microsoft.Network/privateEndpoints",
+                    "evaluationDelay": "PT1M",
+                    "name": "[field('name')]",
+                    "existenceCondition": {
+                        "allOf": [
+                            {
+                                "field": "Microsoft.Network/privateEndpoints/customDnsConfigs[*]",
+                                "exists": true
+                            },
+                            {
+                                "count": {
+                                    "field": "Microsoft.Network/privateEndpoints/customDnsConfigs[*]"
+                                },
+                                "equals": 0
+                            }
+                        ]
                     },
-                    "mode": "Incremental",
-                    "parameters": {
-                      "privateEndpointName": {
-                        "value": "[parameters('privateEndpointName')]"
-                      },
-                      "location": {
-                        "value": "[parameters('location')]"
-                      },
-                      "customDnsConfigs": {
-                        "value": "[map(coalesce(reference(variables('getPECurrentProperties')).outputs.resource.value.properties.customDnsConfigs, createArray()), lambda('dns', lambdaVariables('dns').fqdn))]"
-                      },
-                      "dnsZoneGroupName": {
-                        "value": "[parameters('dnsZoneGroupName')]"
-                      },
-                      "dnsConfigsRG": {
-                        "value": "[parameters('dnsConfigsRG')]"
-                      }
-                    },
-                    "template": {
-                      "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                      "contentVersion": "1.0.0.0",
-                      "parameters": {
-                        "privateEndpointName": {
-                          "type": "string"
-                        },
-                        "location": {
-                          "type": "string"
-                        },
-                        "customDnsConfigs": {
-                          "type": "array"
-                        },
-                        "dnsZoneGroupName": {
-                          "type": "string"
-                        },
-                        "dnsConfigsRG": {
-                          "type": "string"
-                        }
-                      },
-                      "resources": [
-                        {
-                          "name": "[concat(parameters('privateEndpointName'), '/', parameters('dnsZoneGroupName'))]",
-                          "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
-                          "apiVersion": "2024-10-01",
-                          "location": "[parameters('location')]",
-                          "properties": {
-                            "copy": [
-                              {
-                                "name": "privateDnsZoneConfigs",
-                                "count": "[length(parameters('customDnsConfigs'))]",
-                                "input": {
-                                  "name": "[concat('privatelink', replace(substring(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'), sub(length(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')]), indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'))), '.', '-'))]",
-                                  "properties": {
-                                    "privateDnsZoneId": "[concat(parameters('dnsConfigsRG'), '/providers/Microsoft.Network/privateDnsZones/privatelink', substring(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'), sub(length(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')]), indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'))) ) ]"
-                                  }
+                    "roleDefinitionIds": [
+                        "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+                    ],
+                    "deployment": {
+                        "properties": {
+                            "mode": "incremental",
+                            "parameters": {
+                                "privateEndpointName": {
+                                    "value": "[field('name')]"
+                                },
+                                "privateEndpointId": {
+                                    "value": "[field('id')]"
+                                },
+                                "location": {
+                                    "value": "[field('location')]"
+                                },
+                                "dnsZoneGroupName": {
+                                    "value": "[parameters('dnsZoneGroupName')]"
+                                },
+                                "dnsConfigsRG": {
+                                    "value": "[parameters('dnsConfigsRG')]"
                                 }
-                              }
-                            ]
-                          }
+                            },
+                            "template": {
+                                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                "contentVersion": "1.0.0.0",
+                                "parameters": {
+                                    "privateEndpointName": {
+                                        "type": "string"
+                                    },
+                                    "privateEndpointId": {
+                                        "type": "string"
+                                    },
+                                    "location": {
+                                        "type": "string"
+                                    },
+                                    "dnsZoneGroupName": {
+                                        "type": "string"
+                                    },
+                                    "dnsConfigsRG": {
+                                        "type": "string"
+                                    }
+                                },
+                                "variables": {
+                                    "getPECurrentProperties": "[concat('getPECurrentProperties-', uniqueString(deployment().name))]",
+                                    "deployPEDNSConfigs": "[concat('deployPEDNSConfigs-', uniqueString(deployment().name))]"
+                                },
+                                "resources": [
+                                    {
+                                        "type": "Microsoft.Resources/deployments",
+                                        "apiVersion": "2020-06-01",
+                                        "name": "[variables('getPECurrentProperties')]",
+                                        "properties": {
+                                            "expressionEvaluationOptions": {
+                                                "scope": "inner"
+                                            },
+                                            "mode": "Incremental",
+                                            "parameters": {
+                                                "privateEndpointId": {
+                                                    "value": "[parameters('privateEndpointId')]"
+                                                }
+                                            },
+                                            "template": {
+                                                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                                                "contentVersion": "1.0.0.0",
+                                                "parameters": {
+                                                    "privateEndpointId": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "outputs": {
+                                                    "resource": {
+                                                        "type": "object",
+                                                        "value": "[reference(parameters('privateEndpointId'), '2024-10-01', 'Full')]"
+                                                    }
+                                                },
+                                                "resources": []
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "Microsoft.Resources/deployments",
+                                        "apiVersion": "2020-06-01",
+                                        "dependsOn": [
+                                            "[variables('getPECurrentProperties')]"
+                                        ],
+                                        "name": "[variables('deployPEDNSConfigs')]",
+                                        "properties": {
+                                            "expressionEvaluationOptions": {
+                                                "scope": "inner"
+                                            },
+                                            "mode": "Incremental",
+                                            "parameters": {
+                                                "privateEndpointName": {
+                                                    "value": "[parameters('privateEndpointName')]"
+                                                },
+                                                "location": {
+                                                    "value": "[parameters('location')]"
+                                                },
+                                                "customDnsConfigs": {
+                                                    "value": "[map(coalesce(reference(variables('getPECurrentProperties')).outputs.resource.value.properties.customDnsConfigs, createArray()), lambda('dns', lambdaVariables('dns').fqdn))]"
+                                                },
+                                                "dnsZoneGroupName": {
+                                                    "value": "[parameters('dnsZoneGroupName')]"
+                                                },
+                                                "dnsConfigsRG": {
+                                                    "value": "[parameters('dnsConfigsRG')]"
+                                                }
+                                            },
+                                            "template": {
+                                                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                                                "contentVersion": "1.0.0.0",
+                                                "parameters": {
+                                                    "privateEndpointName": {
+                                                        "type": "string"
+                                                    },
+                                                    "location": {
+                                                        "type": "string"
+                                                    },
+                                                    "customDnsConfigs": {
+                                                        "type": "array"
+                                                    },
+                                                    "dnsZoneGroupName": {
+                                                        "type": "string"
+                                                    },
+                                                    "dnsConfigsRG": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "resources": [
+                                                    {
+                                                        "name": "[concat(parameters('privateEndpointName'), '/', parameters('dnsZoneGroupName'))]",
+                                                        "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                                                        "apiVersion": "2024-10-01",
+                                                        "location": "[parameters('location')]",
+                                                        "properties": {
+                                                            "copy": [
+                                                                {
+                                                                    "name": "privateDnsZoneConfigs",
+                                                                    "count": "[length(parameters('customDnsConfigs'))]",
+                                                                    "input": {
+                                                                        "name": "[concat('privatelink', replace(substring(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'), sub(length(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')]), indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'))), '.', '-'))]",
+                                                                        "properties": {
+                                                                            "privateDnsZoneId": "[concat(parameters('dnsConfigsRG'), '/providers/Microsoft.Network/privateDnsZones/privatelink', substring(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'), sub(length(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')]), indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'))) ) ]"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
                         }
-                      ]
                     }
-                  }
                 }
-              ]
             }
-          }
+        },
+        "parameters": {
+            "effect": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Effect",
+                    "description": "Enable or disable the execution of the policy"
+                },
+                "allowedValues": [
+                    "DeployIfNotExists",
+                    "Disabled"
+                ],
+                "defaultValue": "DeployIfNotExists"
+            },
+            "privateEndpointPrivateLinkServiceId": {
+                "type": "string",
+                "metadata": {
+                    "displayName": "Private Endpoint Link Service Id. The list is available in this link: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration",
+                    "description": "A group Id for the private endpoint"
+                }
+            },
+            "privateEndpointGroupId": {
+                "type": "string",
+                "metadata": {
+                    "displayName": "Private Endpoint Group Id",
+                    "description": "A group Id for the private endpoint. The list is available in this link: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration"
+                }
+            },
+            "dnsZoneGroupName": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "DNS Zone Group Name",
+                    "description": "Private DNS Zone Group Name"
+                },
+                "defaultValue": "deployedByPolicy"
+            },
+            "dnsConfigsRG": {
+                "type": "String",
+                "metadata": {
+                    "displayName": "Private DNS Zone Resource Group Resource ID",
+                    "description": "Private DNS Zone Resource Group where the private dns zones exist."
+                }
+            }
         }
-      }
     }
-  },
-  "parameters": {
-    "effect": {
-      "type": "String",
-      "metadata": {
-        "displayName": "Effect",
-        "description": "Enable or disable the execution of the policy"
-      },
-      "allowedValues": [
-        "DeployIfNotExists",
-        "Disabled"
-      ],
-      "defaultValue": "DeployIfNotExists"
-    },
-    "privateEndpointPrivateLinkServiceId": {
-      "type": "string",
-      "metadata": {
-        "displayName": "Private Endpoint Link Service Id. The list is available in this link: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration",
-        "description": "A group Id for the private endpoint"
-      }
-    },
-    "privateEndpointGroupId": {
-      "type": "string",
-      "metadata": {
-        "displayName": "Private Endpoint Group Id",
-        "description": "A group Id for the private endpoint. The list is available in this link: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration"
-      }
-    },
-    "dnsZoneGroupName": {
-      "type": "String",
-      "metadata": {
-        "displayName": "DNS Zone Group Name",
-        "description": "Private DNS Zone Group Name"
-      },
-      "defaultValue": "deployedByPolicy"
-    },
-    "dnsConfigsRG": {
-      "type": "String",
-      "metadata": {
-        "displayName": "Private DNS Zone Resource Group Resource ID",
-        "description": "Private DNS Zone Resource Group where the private dns zones exist."
-      }
-    }
-  }
 }

--- a/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.json
+++ b/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.json
@@ -1,0 +1,254 @@
+{
+  "mode": "Indexed",
+  "policyRule": {
+    "if": {
+      "allOf": [
+        {
+          "field": "type",
+          "equals": "Microsoft.Network/privateEndpoints"
+        },
+        {
+          "count": {
+            "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
+            "where": {
+              "allOf": [
+                {
+                  "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+                  "contains": "[parameters('privateEndpointPrivateLinkServiceId')]"
+                },
+                {
+                  "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+                  "equals": "[parameters('privateEndpointGroupId')]"
+                }
+              ]
+            }
+          },
+          "greaterOrEquals": 1
+        }
+      ]
+    },
+    "then": {
+      "effect": "[parameters('effect')]",
+      "details": {
+        "type": "Microsoft.Network/privateEndpoints",
+        "evaluationDelay": "PT5M",
+        "name": "[field('name')]",
+        "existenceCondition": {
+          "allOf": [
+            {
+              "field": "Microsoft.Network/privateEndpoints/customDnsConfigs[*]",
+              "exists": true
+            },
+            {
+              "count": {
+                "field": "Microsoft.Network/privateEndpoints/customDnsConfigs[*]"
+              },
+              "equals": 0
+            }
+          ]
+        },
+        "roleDefinitionIds": [
+          "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+        ],
+        "deployment": {
+          "properties": {
+            "mode": "incremental",
+            "parameters": {
+              "privateEndpointName": {
+                "value": "[field('name')]"
+              },
+              "privateEndpointId": {
+                "value": "[field('id')]"
+              },
+              "location": {
+                "value": "[field('location')]"
+              },
+              "dnsZoneGroupName": {
+                "value": "[parameters('dnsZoneGroupName')]"
+              },
+              "dnsConfigsRG": {
+                "value": "[parameters('dnsConfigsRG')]"
+              }
+            },
+            "template": {
+              "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "privateEndpointName": {
+                  "type": "string"
+                },
+                "privateEndpointId": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                },
+                "dnsZoneGroupName": {
+                  "type": "string"
+                },
+                "dnsConfigsRG": {
+                  "type": "string"
+                }
+              },
+              "variables": {
+                "getPECurrentProperties": "[concat('getPECurrentProperties-', uniqueString(deployment().name))]",
+                "deployPEDNSConfigs": "[concat('deployPEDNSConfigs-', uniqueString(deployment().name))]"
+              },
+              "resources": [
+                {
+                  "type": "Microsoft.Resources/deployments",
+                  "apiVersion": "2020-06-01",
+                  "name": "[variables('getPECurrentProperties')]",
+                  "properties": {
+                    "expressionEvaluationOptions": {
+                      "scope": "inner"
+                    },
+                    "mode": "Incremental",
+                    "parameters": {
+                      "privateEndpointId": {
+                        "value": "[parameters('privateEndpointId')]"
+                      }
+                    },
+                    "template": {
+                      "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                      "contentVersion": "1.0.0.0",
+                      "parameters": {
+                        "privateEndpointId": {
+                          "type": "string"
+                        }
+                      },
+                      "outputs": {
+                        "resource": {
+                          "type": "object",
+                          "value": "[reference(parameters('privateEndpointId'), '2024-10-01', 'Full')]"
+                        }
+                      },
+                      "resources": []
+                    }
+                  }
+                },
+                {
+                  "type": "Microsoft.Resources/deployments",
+                  "apiVersion": "2020-06-01",
+                  "dependsOn": [
+                    "[variables('getPECurrentProperties')]"
+                  ],
+                  "name": "[variables('deployPEDNSConfigs')]",
+                  "properties": {
+                    "expressionEvaluationOptions": {
+                      "scope": "inner"
+                    },
+                    "mode": "Incremental",
+                    "parameters": {
+                      "privateEndpointName": {
+                        "value": "[parameters('privateEndpointName')]"
+                      },
+                      "location": {
+                        "value": "[parameters('location')]"
+                      },
+                      "customDnsConfigs": {
+                        "value": "[map(coalesce(reference(variables('getPECurrentProperties')).outputs.resource.value.properties.customDnsConfigs, createArray()), lambda('dns', lambdaVariables('dns').fqdn))]"
+                      },
+                      "dnsZoneGroupName": {
+                        "value": "[parameters('dnsZoneGroupName')]"
+                      },
+                      "dnsConfigsRG": {
+                        "value": "[parameters('dnsConfigsRG')]"
+                      }
+                    },
+                    "template": {
+                      "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                      "contentVersion": "1.0.0.0",
+                      "parameters": {
+                        "privateEndpointName": {
+                          "type": "string"
+                        },
+                        "location": {
+                          "type": "string"
+                        },
+                        "customDnsConfigs": {
+                          "type": "array"
+                        },
+                        "dnsZoneGroupName": {
+                          "type": "string"
+                        },
+                        "dnsConfigsRG": {
+                          "type": "string"
+                        }
+                      },
+                      "resources": [
+                        {
+                          "name": "[concat(parameters('privateEndpointName'), '/', parameters('dnsZoneGroupName'))]",
+                          "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                          "apiVersion": "2024-10-01",
+                          "location": "[parameters('location')]",
+                          "properties": {
+                            "copy": [
+                              {
+                                "name": "privateDnsZoneConfigs",
+                                "count": "[length(parameters('customDnsConfigs'))]",
+                                "input": {
+                                  "name": "[concat('privatelink', replace(substring(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'), sub(length(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')]), indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'))), '.', '-'))]",
+                                  "properties": {
+                                    "privateDnsZoneId": "[concat(parameters('dnsConfigsRG'), '/providers/Microsoft.Network/privateDnsZones/privatelink', substring(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'), sub(length(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')]), indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'))) ) ]"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Enable or disable the execution of the policy"
+      },
+      "allowedValues": [
+        "DeployIfNotExists",
+        "Disabled"
+      ],
+      "defaultValue": "DeployIfNotExists"
+    },
+    "privateEndpointPrivateLinkServiceId": {
+      "type": "string",
+      "metadata": {
+        "displayName": "Private Endpoint Link Service Id. The list is available in this link: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration",
+        "description": "A group Id for the private endpoint"
+      }
+    },
+    "privateEndpointGroupId": {
+      "type": "string",
+      "metadata": {
+        "displayName": "Private Endpoint Group Id",
+        "description": "A group Id for the private endpoint. The list is available in this link: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration"
+      }
+    },
+    "dnsZoneGroupName": {
+      "type": "String",
+      "metadata": {
+        "displayName": "DNS Zone Group Name",
+        "description": "Private DNS Zone Group Name"
+      },
+      "defaultValue": "deployedByPolicy"
+    },
+    "dnsConfigsRG": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Private DNS Zone Resource Group Resource ID",
+        "description": "Private DNS Zone Resource Group where the private dns zones exist."
+      }
+    }
+  }
+}

--- a/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.json
+++ b/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.json
@@ -10,213 +10,232 @@
         },
         "mode": "Indexed",
         "policyRule": {
-            "if": {
-                "allOf": [
-                    {
-                        "field": "type",
-                        "equals": "Microsoft.Network/privateEndpoints"
-                    },
-                    {
-                        "count": {
-                            "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
-                            "where": {
-                                "allOf": [
-                                    {
-                                        "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
-                                        "contains": "[parameters('privateEndpointPrivateLinkServiceId')]"
-                                    },
-                                    {
-                                        "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
-                                        "equals": "[parameters('privateEndpointGroupId')]"
-                                    }
-                                ]
-                            }
-                        },
-                        "greaterOrEquals": 1
-                    }
-                ]
-            },
-            "then": {
-                "effect": "[parameters('effect')]",
-                "details": {
-                    "type": "Microsoft.Network/privateEndpoints",
-                    "evaluationDelay": "PT1M",
-                    "name": "[field('name')]",
-                    "existenceCondition": {
-                        "allOf": [
-                            {
-                                "field": "Microsoft.Network/privateEndpoints/customDnsConfigs[*]",
-                                "exists": true
-                            },
-                            {
-                                "count": {
-                                    "field": "Microsoft.Network/privateEndpoints/customDnsConfigs[*]"
-                                },
-                                "equals": 0
-                            }
-                        ]
-                    },
-                    "roleDefinitionIds": [
-                        "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
-                    ],
-                    "deployment": {
-                        "properties": {
-                            "mode": "incremental",
-                            "parameters": {
-                                "privateEndpointName": {
-                                    "value": "[field('name')]"
-                                },
-                                "privateEndpointId": {
-                                    "value": "[field('id')]"
-                                },
-                                "location": {
-                                    "value": "[field('location')]"
-                                },
-                                "dnsZoneGroupName": {
-                                    "value": "[parameters('dnsZoneGroupName')]"
-                                },
-                                "dnsConfigsRG": {
-                                    "value": "[parameters('dnsConfigsRG')]"
-                                }
-                            },
-                            "template": {
-                                "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                                "contentVersion": "1.0.0.0",
-                                "parameters": {
-                                    "privateEndpointName": {
-                                        "type": "string"
-                                    },
-                                    "privateEndpointId": {
-                                        "type": "string"
-                                    },
-                                    "location": {
-                                        "type": "string"
-                                    },
-                                    "dnsZoneGroupName": {
-                                        "type": "string"
-                                    },
-                                    "dnsConfigsRG": {
-                                        "type": "string"
-                                    }
-                                },
-                                "variables": {
-                                    "getPECurrentProperties": "[concat('getPECurrentProperties-', uniqueString(deployment().name))]",
-                                    "deployPEDNSConfigs": "[concat('deployPEDNSConfigs-', uniqueString(deployment().name))]"
-                                },
-                                "resources": [
-                                    {
-                                        "type": "Microsoft.Resources/deployments",
-                                        "apiVersion": "2020-06-01",
-                                        "name": "[variables('getPECurrentProperties')]",
-                                        "properties": {
-                                            "expressionEvaluationOptions": {
-                                                "scope": "inner"
-                                            },
-                                            "mode": "Incremental",
-                                            "parameters": {
-                                                "privateEndpointId": {
-                                                    "value": "[parameters('privateEndpointId')]"
-                                                }
-                                            },
-                                            "template": {
-                                                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                                                "contentVersion": "1.0.0.0",
-                                                "parameters": {
-                                                    "privateEndpointId": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "outputs": {
-                                                    "resource": {
-                                                        "type": "object",
-                                                        "value": "[reference(parameters('privateEndpointId'), '2024-10-01', 'Full')]"
-                                                    }
-                                                },
-                                                "resources": []
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "type": "Microsoft.Resources/deployments",
-                                        "apiVersion": "2020-06-01",
-                                        "dependsOn": [
-                                            "[variables('getPECurrentProperties')]"
-                                        ],
-                                        "name": "[variables('deployPEDNSConfigs')]",
-                                        "properties": {
-                                            "expressionEvaluationOptions": {
-                                                "scope": "inner"
-                                            },
-                                            "mode": "Incremental",
-                                            "parameters": {
-                                                "privateEndpointName": {
-                                                    "value": "[parameters('privateEndpointName')]"
-                                                },
-                                                "location": {
-                                                    "value": "[parameters('location')]"
-                                                },
-                                                "customDnsConfigs": {
-                                                    "value": "[map(coalesce(reference(variables('getPECurrentProperties')).outputs.resource.value.properties.customDnsConfigs, createArray()), lambda('dns', lambdaVariables('dns').fqdn))]"
-                                                },
-                                                "dnsZoneGroupName": {
-                                                    "value": "[parameters('dnsZoneGroupName')]"
-                                                },
-                                                "dnsConfigsRG": {
-                                                    "value": "[parameters('dnsConfigsRG')]"
-                                                }
-                                            },
-                                            "template": {
-                                                "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                                                "contentVersion": "1.0.0.0",
-                                                "parameters": {
-                                                    "privateEndpointName": {
-                                                        "type": "string"
-                                                    },
-                                                    "location": {
-                                                        "type": "string"
-                                                    },
-                                                    "customDnsConfigs": {
-                                                        "type": "array"
-                                                    },
-                                                    "dnsZoneGroupName": {
-                                                        "type": "string"
-                                                    },
-                                                    "dnsConfigsRG": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "resources": [
-                                                    {
-                                                        "name": "[concat(parameters('privateEndpointName'), '/', parameters('dnsZoneGroupName'))]",
-                                                        "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
-                                                        "apiVersion": "2024-10-01",
-                                                        "location": "[parameters('location')]",
-                                                        "properties": {
-                                                            "copy": [
-                                                                {
-                                                                    "name": "privateDnsZoneConfigs",
-                                                                    "count": "[length(parameters('customDnsConfigs'))]",
-                                                                    "input": {
-                                                                        "name": "[concat('privatelink', replace(substring(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'), sub(length(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')]), indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'))), '.', '-'))]",
-                                                                        "properties": {
-                                                                            "privateDnsZoneId": "[concat(parameters('dnsConfigsRG'), '/providers/Microsoft.Network/privateDnsZones/privatelink', substring(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'), sub(length(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')]), indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'))) ) ]"
-                                                                        }
-                                                                    }
-                                                                }
-                                                            ]
-                                                        }
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
+    "if": {
+      "allOf": [
+        {
+          "field": "type",
+          "equals": "Microsoft.Network/privateEndpoints"
         },
+        {
+          "count": {
+            "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
+            "where": {
+              "allOf": [
+                {
+                  "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+                  "contains": "[parameters('privateEndpointPrivateLinkServiceId')]"
+                },
+                {
+                  "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+                  "equals": "[parameters('privateEndpointGroupId')]"
+                }
+              ]
+            }
+          },
+          "greaterOrEquals": 1
+        }
+      ]
+    },
+    "then": {
+      "effect": "[parameters('effect')]",
+      "details": {
+        "type": "Microsoft.Network/privateEndpoints",
+        "evaluationDelay": "PT1M",
+        "name": "[field('name')]",
+        "existenceCondition": {
+          "allOf": [
+            {
+              "field": "Microsoft.Network/privateEndpoints/customDnsConfigs[*]",
+              "exists": true
+            },
+            {
+              "count": {
+                "field": "Microsoft.Network/privateEndpoints/customDnsConfigs[*]"
+              },
+              "equals": 0
+            }
+          ]
+        },
+        "roleDefinitionIds": [
+          "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+        ],
+        "deployment": {
+          "properties": {
+            "mode": "incremental",
+            "parameters": {
+              "privateEndpointName": {
+                "value": "[field('name')]"
+              },
+              "privateEndpointId": {
+                "value": "[field('id')]"
+              },
+              "location": {
+                "value": "[field('location')]"
+              },
+              "dnsZoneGroupName": {
+                "value": "[parameters('dnsZoneGroupName')]"
+              },
+              "dnsConfigsRG": {
+                "value": "[parameters('dnsConfigsRG')]"
+              },
+              "privateEndpointPrivateLinkServiceId": {
+                "value": "[parameters('privateEndpointPrivateLinkServiceId')]"
+              },
+              "privateEndpointGroupId": {
+                "value": "[parameters('privateEndpointGroupId')]"
+              }
+            },
+            "template": {
+              "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "privateEndpointName": {
+                  "type": "string"
+                },
+                "privateEndpointId": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                },
+                "dnsZoneGroupName": {
+                  "type": "string"
+                },
+                "dnsConfigsRG": {
+                  "type": "string"
+                },
+                "privateEndpointPrivateLinkServiceId": {
+                  "type": "string"
+                },
+                "privateEndpointGroupId": {
+                  "type": "string"
+                }
+              },
+              "variables": {
+                "getPECurrentProperties": "[concat('getPECurrentProperties-', uniqueString(deployment().name))]",
+                "deployPEDNSConfigs": "[concat('deployPEDNSConfigs-', uniqueString(deployment().name))]",
+                "mappedName": "[concat(tolower(parameters('privateEndpointPrivateLinkServiceId')), '/', tolower(parameters('privateEndpointGroupId')) )]",
+                "mappings":{
+                  "microsoft.keyvault/vaults/vault" : [
+                    ".vault.",
+                    ".vaultcore."
+                  ]
+                }
+              },
+              "resources": [
+                {
+                  "type": "Microsoft.Resources/deployments",
+                  "apiVersion": "2020-06-01",
+                  "name": "[variables('getPECurrentProperties')]",
+                  "properties": {
+                    "expressionEvaluationOptions": {
+                      "scope": "inner"
+                    },
+                    "mode": "Incremental",
+                    "parameters": {
+                      "privateEndpointId": {
+                        "value": "[parameters('privateEndpointId')]"
+                      }
+                    },
+                    "template": {
+                      "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                      "contentVersion": "1.0.0.0",
+                      "parameters": {
+                        "privateEndpointId": {
+                          "type": "string"
+                        }
+                      },
+                      "outputs": {
+                        "resource": {
+                          "type": "object",
+                          "value": "[reference(parameters('privateEndpointId'), '2024-10-01', 'Full')]"
+                        }
+                      },
+                      "resources": []
+                    }
+                  }
+                },
+                {
+                  "type": "Microsoft.Resources/deployments",
+                  "apiVersion": "2020-06-01",
+                  "dependsOn": [
+                    "[variables('getPECurrentProperties')]"
+                  ],
+                  "name": "[variables('deployPEDNSConfigs')]",
+                  "properties": {
+                    "expressionEvaluationOptions": {
+                      "scope": "inner"
+                    },
+                    "mode": "Incremental",
+                    "parameters": {
+                      "privateEndpointName": {
+                        "value": "[parameters('privateEndpointName')]"
+                      },
+                      "location": {
+                        "value": "[parameters('location')]"
+                      },
+                      "customDnsConfigs": {
+                        "value": "[if(equals(tryGet(variables('mappings'), variables('mappedName')), null()), map(coalesce(reference(variables('getPECurrentProperties')).outputs.resource.value.properties.customDnsConfigs, createArray()), lambda('dns', lambdaVariables('dns').fqdn)),  map(coalesce(reference(variables('getPECurrentProperties')).outputs.resource.value.properties.customDnsConfigs, createArray()), lambda('dns', replace(lambdaVariables('dns').fqdn, tryGet(variables('mappings'), variables('mappedName'))[0], tryGet(variables('mappings'), variables('mappedName'))[1]))) )]"
+                      },
+                      "dnsZoneGroupName": {
+                        "value": "[parameters('dnsZoneGroupName')]"
+                      },
+                      "dnsConfigsRG": {
+                        "value": "[parameters('dnsConfigsRG')]"
+                      }
+                    },
+                    "template": {
+                      "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                      "contentVersion": "1.0.0.0",
+                      "parameters": {
+                        "privateEndpointName": {
+                          "type": "string"
+                        },
+                        "location": {
+                          "type": "string"
+                        },
+                        "customDnsConfigs": {
+                          "type": "array"
+                        },
+                        "dnsZoneGroupName": {
+                          "type": "string"
+                        },
+                        "dnsConfigsRG": {
+                          "type": "string"
+                        }
+                      },
+                      "resources": [
+                        {
+                          "name": "[concat(parameters('privateEndpointName'), '/', parameters('dnsZoneGroupName'))]",
+                          "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                          "apiVersion": "2024-10-01",
+                          "location": "[parameters('location')]",
+                          "properties": {
+                            "copy": [
+                              {
+                                "name": "privateDnsZoneConfigs",
+                                "count": "[length(parameters('customDnsConfigs'))]",
+                                "input": {
+                                  "name": "[concat('privatelink', replace(substring(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'), sub(length(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')]), indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'))), '.', '-'))]",
+                                  "properties": {
+                                    "privateDnsZoneId": "[concat(parameters('dnsConfigsRG'), '/providers/Microsoft.Network/privateDnsZones/privatelink', substring(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'), sub(length(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')]), indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'))) ) ]"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
         "parameters": {
             "effect": {
                 "type": "String",

--- a/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.parameters.json
+++ b/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.parameters.json
@@ -1,0 +1,43 @@
+{
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Enable or disable the execution of the policy"
+      },
+      "allowedValues": [
+        "DeployIfNotExists",
+        "Disabled"
+      ],
+      "defaultValue": "DeployIfNotExists"
+    },
+    "privateEndpointPrivateLinkServiceId": {
+      "type": "string",
+      "metadata": {
+        "displayName": "Private Endpoint Link Service Id. The list is available in this link: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration",
+        "description": "A group Id for the private endpoint"
+      }
+    },
+    "privateEndpointGroupId": {
+      "type": "string",
+      "metadata": {
+        "displayName": "Private Endpoint Group Id",
+        "description": "A group Id for the private endpoint. The list is available in this link: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration"
+      }
+    },
+    "dnsZoneGroupName": {
+      "type": "String",
+      "metadata": {
+        "displayName": "DNS Zone Group Name",
+        "description": "Private DNS Zone Group Name"
+      },
+      "defaultValue": "deployedByPolicy"
+    },
+    "dnsConfigsRG": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Private DNS Zone Resource Group Resource ID",
+        "description": "Private DNS Zone Resource Group where the private dns zones exist."
+      }
+    }
+  }

--- a/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.rules.json
+++ b/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.rules.json
@@ -1,0 +1,208 @@
+{
+    "if": {
+      "allOf": [
+        {
+          "field": "type",
+          "equals": "Microsoft.Network/privateEndpoints"
+        },
+        {
+          "count": {
+            "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*]",
+            "where": {
+              "allOf": [
+                {
+                  "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+                  "contains": "[parameters('privateEndpointPrivateLinkServiceId')]"
+                },
+                {
+                  "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].groupIds[*]",
+                  "equals": "[parameters('privateEndpointGroupId')]"
+                }
+              ]
+            }
+          },
+          "greaterOrEquals": 1
+        }
+      ]
+    },
+    "then": {
+      "effect": "[parameters('effect')]",
+      "details": {
+        "type": "Microsoft.Network/privateEndpoints",
+        "evaluationDelay": "PT5M",
+        "name": "[field('name')]",
+        "existenceCondition": {
+          "allOf": [
+            {
+              "field": "Microsoft.Network/privateEndpoints/customDnsConfigs[*]",
+              "exists": true
+            },
+            {
+              "count": {
+                "field": "Microsoft.Network/privateEndpoints/customDnsConfigs[*]"
+              },
+              "equals": 0
+            }
+          ]
+        },
+        "roleDefinitionIds": [
+          "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7"
+        ],
+        "deployment": {
+          "properties": {
+            "mode": "incremental",
+            "parameters": {
+              "privateEndpointName": {
+                "value": "[field('name')]"
+              },
+              "privateEndpointId": {
+                "value": "[field('id')]"
+              },
+              "location": {
+                "value": "[field('location')]"
+              },
+              "dnsZoneGroupName": {
+                "value": "[parameters('dnsZoneGroupName')]"
+              },
+              "dnsConfigsRG": {
+                "value": "[parameters('dnsConfigsRG')]"
+              }
+            },
+            "template": {
+              "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "privateEndpointName": {
+                  "type": "string"
+                },
+                "privateEndpointId": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                },
+                "dnsZoneGroupName": {
+                  "type": "string"
+                },
+                "dnsConfigsRG": {
+                  "type": "string"
+                }
+              },
+              "variables": {
+                "getPECurrentProperties": "[concat('getPECurrentProperties-', uniqueString(deployment().name))]",
+                "deployPEDNSConfigs": "[concat('deployPEDNSConfigs-', uniqueString(deployment().name))]"
+              },
+              "resources": [
+                {
+                  "type": "Microsoft.Resources/deployments",
+                  "apiVersion": "2020-06-01",
+                  "name": "[variables('getPECurrentProperties')]",
+                  "properties": {
+                    "expressionEvaluationOptions": {
+                      "scope": "inner"
+                    },
+                    "mode": "Incremental",
+                    "parameters": {
+                      "privateEndpointId": {
+                        "value": "[parameters('privateEndpointId')]"
+                      }
+                    },
+                    "template": {
+                      "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                      "contentVersion": "1.0.0.0",
+                      "parameters": {
+                        "privateEndpointId": {
+                          "type": "string"
+                        }
+                      },
+                      "outputs": {
+                        "resource": {
+                          "type": "object",
+                          "value": "[reference(parameters('privateEndpointId'), '2024-10-01', 'Full')]"
+                        }
+                      },
+                      "resources": []
+                    }
+                  }
+                },
+                {
+                  "type": "Microsoft.Resources/deployments",
+                  "apiVersion": "2020-06-01",
+                  "dependsOn": [
+                    "[variables('getPECurrentProperties')]"
+                  ],
+                  "name": "[variables('deployPEDNSConfigs')]",
+                  "properties": {
+                    "expressionEvaluationOptions": {
+                      "scope": "inner"
+                    },
+                    "mode": "Incremental",
+                    "parameters": {
+                      "privateEndpointName": {
+                        "value": "[parameters('privateEndpointName')]"
+                      },
+                      "location": {
+                        "value": "[parameters('location')]"
+                      },
+                      "customDnsConfigs": {
+                        "value": "[map(coalesce(reference(variables('getPECurrentProperties')).outputs.resource.value.properties.customDnsConfigs, createArray()), lambda('dns', lambdaVariables('dns').fqdn))]"
+                      },
+                      "dnsZoneGroupName": {
+                        "value": "[parameters('dnsZoneGroupName')]"
+                      },
+                      "dnsConfigsRG": {
+                        "value": "[parameters('dnsConfigsRG')]"
+                      }
+                    },
+                    "template": {
+                      "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                      "contentVersion": "1.0.0.0",
+                      "parameters": {
+                        "privateEndpointName": {
+                          "type": "string"
+                        },
+                        "location": {
+                          "type": "string"
+                        },
+                        "customDnsConfigs": {
+                          "type": "array"
+                        },
+                        "dnsZoneGroupName": {
+                          "type": "string"
+                        },
+                        "dnsConfigsRG": {
+                          "type": "string"
+                        }
+                      },
+                      "resources": [
+                        {
+                          "name": "[concat(parameters('privateEndpointName'), '/', parameters('dnsZoneGroupName'))]",
+                          "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                          "apiVersion": "2024-10-01",
+                          "location": "[parameters('location')]",
+                          "properties": {
+                            "copy": [
+                              {
+                                "name": "privateDnsZoneConfigs",
+                                "count": "[length(parameters('customDnsConfigs'))]",
+                                "input": {
+                                  "name": "[concat('privatelink', replace(substring(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'), sub(length(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')]), indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'))), '.', '-'))]",
+                                  "properties": {
+                                    "privateDnsZoneId": "[concat(parameters('dnsConfigsRG'), '/providers/Microsoft.Network/privateDnsZones/privatelink', substring(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'), sub(length(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')]), indexOf(parameters('customDnsConfigs')[copyIndex('privateDnsZoneConfigs')], '.'))) ) ]"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }

--- a/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.rules.json
+++ b/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.rules.json
@@ -66,6 +66,12 @@
               },
               "dnsConfigsRG": {
                 "value": "[parameters('dnsConfigsRG')]"
+              },
+              "privateEndpointPrivateLinkServiceId": {
+                "value": "[parameters('privateEndpointPrivateLinkServiceId')]"
+              },
+              "privateEndpointGroupId": {
+                "value": "[parameters('privateEndpointGroupId')]"
               }
             },
             "template": {
@@ -86,11 +92,24 @@
                 },
                 "dnsConfigsRG": {
                   "type": "string"
+                },
+                "privateEndpointPrivateLinkServiceId": {
+                  "type": "string"
+                },
+                "privateEndpointGroupId": {
+                  "type": "string"
                 }
               },
               "variables": {
                 "getPECurrentProperties": "[concat('getPECurrentProperties-', uniqueString(deployment().name))]",
-                "deployPEDNSConfigs": "[concat('deployPEDNSConfigs-', uniqueString(deployment().name))]"
+                "deployPEDNSConfigs": "[concat('deployPEDNSConfigs-', uniqueString(deployment().name))]",
+                "mappedName": "[concat(tolower(parameters('privateEndpointPrivateLinkServiceId')), '/', tolower(parameters('privateEndpointGroupId')) )]",
+                "mappings":{
+                  "microsoft.keyvault/vaults/vault" : [
+                    ".vault.",
+                    ".vaultcore."
+                  ]
+                }
               },
               "resources": [
                 {
@@ -145,7 +164,7 @@
                         "value": "[parameters('location')]"
                       },
                       "customDnsConfigs": {
-                        "value": "[map(coalesce(reference(variables('getPECurrentProperties')).outputs.resource.value.properties.customDnsConfigs, createArray()), lambda('dns', lambdaVariables('dns').fqdn))]"
+                        "value": "[if(equals(tryGet(variables('mappings'), variables('mappedName')), null()), map(coalesce(reference(variables('getPECurrentProperties')).outputs.resource.value.properties.customDnsConfigs, createArray()), lambda('dns', lambdaVariables('dns').fqdn)),  map(coalesce(reference(variables('getPECurrentProperties')).outputs.resource.value.properties.customDnsConfigs, createArray()), lambda('dns', replace(lambdaVariables('dns').fqdn, tryGet(variables('mappings'), variables('mappedName'))[0], tryGet(variables('mappings'), variables('mappedName'))[1]))) )]"
                       },
                       "dnsZoneGroupName": {
                         "value": "[parameters('dnsZoneGroupName')]"

--- a/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.rules.json
+++ b/policyDefinitions/Network/configure-private-endpoint-to-use-private-dns-zones-generic/azurepolicy.rules.json
@@ -29,7 +29,7 @@
       "effect": "[parameters('effect')]",
       "details": {
         "type": "Microsoft.Network/privateEndpoints",
-        "evaluationDelay": "PT5M",
+        "evaluationDelay": "PT1M",
         "name": "[field('name')]",
         "existenceCondition": {
           "allOf": [


### PR DESCRIPTION
The built-in policies we have besides being 1 policy for each serive the compliance doesn't work as expected.
If we delete the record from portal the compliance doesn't change therefore you might end up with resouces non-compliant marked as compliant.
This policy solves that problem and the different number of DNS records for the same resource type e.g: Open AI and AI Foundry

The logic of the policy is to take the customDnsRecors and from there choose which private DNS zone name to use.
There are some resources that don't folow this logic E.g: Key Vault uses privateDNS Zone : privatelink.vaultcore.azure.net but CustomDNSRecord is xxxxx.vault.azure.net
In this case we have to add mappings in the template part as I did for AKV.
 Lowercase values for the key of the object to be added followed by an array with 2 items, first the forward part that we are going to replace , then the value that we will replace with:
 Example
"mappings":{
                  "microsoft.keyvault/vaults/vault" : [
                    ".vault.",
                    ".vaultcore."
                  ]
                }
                
            

