### PR TITLE
deploy-<linux|windows>-vm-app: Update treatFailureAsDeploymentFailure  message to match variable name

### DIFF
--- a/policyDefinitions/Compute/deploy-linux-vm-app/azurepolicy.json
+++ b/policyDefinitions/Compute/deploy-linux-vm-app/azurepolicy.json
@@ -42,8 +42,8 @@
 			"treatFailureAsDeploymentFailure": {
 				"type": "Boolean",
 				"metadata": {
-					"displayName": "Treat Failure As Deployment Success",
-					"description": "The VM application extension always returns a success regardless of whether any VM app failed while being installed/updated/removed",
+					"displayName": "Treat Failure As Deployment Failure",
+					"description": "Mark application failure as VM deployment failure for failure handling while being installed/updated/removed",
 					"portalReview": true
 				},
 				"defaultValue": false

--- a/policyDefinitions/Compute/deploy-linux-vm-app/azurepolicy.parameters.json
+++ b/policyDefinitions/Compute/deploy-linux-vm-app/azurepolicy.parameters.json
@@ -34,7 +34,7 @@
 		"type": "Boolean",
 		"metadata": {
 			"displayName": "Treat Failure As Deployment Failure",
-			"description": " Mark application failure as VM deployment failure for failure handling while being installed/updated/removed",
+			"description": "Mark application failure as VM deployment failure for failure handling while being installed/updated/removed",
 			"portalReview": true
 		},
 		"defaultValue": false

--- a/policyDefinitions/Compute/deploy-linux-vm-app/azurepolicy.parameters.json
+++ b/policyDefinitions/Compute/deploy-linux-vm-app/azurepolicy.parameters.json
@@ -33,8 +33,8 @@
 	"treatFailureAsDeploymentFailure": {
 		"type": "Boolean",
 		"metadata": {
-			"displayName": "Treat Failure As Deployment Success",
-			"description": "The VM application extension always returns a success regardless of whether any VM app failed while being installed/updated/removed",
+			"displayName": "Treat Failure As Deployment Failure",
+			"description": " Mark application failure as VM deployment failure for failure handling while being installed/updated/removed",
 			"portalReview": true
 		},
 		"defaultValue": false

--- a/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
+++ b/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.json
@@ -42,8 +42,8 @@
 			"treatFailureAsDeploymentFailure": {
 				"type": "Boolean",
 				"metadata": {
-					"displayName": "Treat Failure As Deployment Success",
-					"description": "The VM application extension always returns a success regardless of whether any VM app failed while being installed/updated/removed",
+					"displayName": "Treat Failure As Deployment Failure",
+					"description": "Mark application failure as VM deployment failure for failure handling while being installed/updated/removed",
 					"portalReview": true
 				},
 				"defaultValue": false

--- a/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.parameters.json
+++ b/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.parameters.json
@@ -34,7 +34,7 @@
 		"type": "Boolean",
 		"metadata": {
 			"displayName": "Treat Failure As Deployment Failure",
-			"description": " Mark application failure as VM deployment failure for failure handling while being installed/updated/removed",
+			"description": "Mark application failure as VM deployment failure for failure handling while being installed/updated/removed",
 			"portalReview": true
 		},
 		"defaultValue": false

--- a/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.parameters.json
+++ b/policyDefinitions/Compute/deploy-windows-vm-app/azurepolicy.parameters.json
@@ -33,8 +33,8 @@
 	"treatFailureAsDeploymentFailure": {
 		"type": "Boolean",
 		"metadata": {
-			"displayName": "Treat Failure As Deployment Success",
-			"description": "The VM application extension always returns a success regardless of whether any VM app failed while being installed/updated/removed",
+			"displayName": "Treat Failure As Deployment Failure",
+			"description": " Mark application failure as VM deployment failure for failure handling while being installed/updated/removed",
 			"portalReview": true
 		},
 		"defaultValue": false


### PR DESCRIPTION

This PR updates the description of the policy so it matches the variable name.

Description taken from azure docs here https://learn.microsoft.com/en-us/azure/virtual-machines/vm-applications#properties-in-applicationprofile-of-vm-and-virtual-machine-scale-sets



<img width="816" height="499" alt="image" src="https://github.com/user-attachments/assets/8ac0762a-9add-4f91-8543-24d31373640a" />
