### PR TITLE
Add policy to audit or upgrade BlobStorage accounts to StorageV2

### DIFF
--- a/policyDefinitions/Storage/storage-account-upgrade-blobstorage-account-to-gpv2/azurepolicy.json
+++ b/policyDefinitions/Storage/storage-account-upgrade-blobstorage-account-to-gpv2/azurepolicy.json
@@ -1,0 +1,106 @@
+{
+  "name": "c0f34c64-8a8f-4e9c-b6b3-3f5cf0d3e001",
+  "mode": "Indexed",
+  "displayName": "Upgrade BlobStorage accounts to StorageV2",
+  "description": "Audits or upgrades legacy BlobStorage accounts to StorageV2 while preserving the existing storage account redundancy SKU and access tier.",
+  "metadata": {
+    "category": "Storage",
+    "version": "1.0.0"
+  },
+  "parameters": {
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Audit or automatically upgrade BlobStorage accounts to StorageV2."
+      },
+      "allowedValues": [
+        "AuditIfNotExists",
+        "DeployIfNotExists",
+        "Disabled"
+      ],
+      "defaultValue": "AuditIfNotExists"
+    }
+  },
+  "policyRule": {
+    "if": {
+      "allOf": [
+        {
+          "field": "type",
+          "equals": "Microsoft.Storage/storageAccounts"
+        },
+        {
+          "field": "kind",
+          "equals": "BlobStorage"
+        }
+      ]
+    },
+    "then": {
+      "effect": "[parameters('effect')]",
+      "details": {
+        "type": "Microsoft.Storage/storageAccounts",
+        "name": "[field('name')]",
+        "existenceCondition": {
+          "field": "kind",
+          "equals": "StorageV2"
+        },
+        "roleDefinitionIds": [
+          "/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab"
+        ],
+        "deploymentScope": "resourceGroup",
+        "deployment": {
+          "properties": {
+            "mode": "Incremental",
+            "parameters": {
+              "storageAccountName": {
+                "value": "[field('name')]"
+              },
+              "location": {
+                "value": "[field('location')]"
+              },
+              "skuName": {
+                "value": "[field('Microsoft.Storage/storageAccounts/sku.name')]"
+              },
+              "accessTier": {
+                "value": "[field('Microsoft.Storage/storageAccounts/accessTier')]"
+              }
+            },
+            "template": {
+              "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "storageAccountName": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                },
+                "skuName": {
+                  "type": "string"
+                },
+                "accessTier": {
+                  "type": "string"
+                }
+              },
+              "resources": [
+                {
+                  "type": "Microsoft.Storage/storageAccounts",
+                  "apiVersion": "2023-01-01",
+                  "name": "[parameters('storageAccountName')]",
+                  "location": "[parameters('location')]",
+                  "sku": {
+                    "name": "[parameters('skuName')]"
+                  },
+                  "kind": "StorageV2",
+                  "properties": {
+                    "accessTier": "[parameters('accessTier')]"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/Storage/storage-account-upgrade-blobstorage-account-to-gpv2/azurepolicy.parameters.json
+++ b/policyDefinitions/Storage/storage-account-upgrade-blobstorage-account-to-gpv2/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Audit or automatically upgrade BlobStorage accounts to StorageV2."
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/policyDefinitions/Storage/storage-account-upgrade-blobstorage-account-to-gpv2/azurepolicy.rules.json
+++ b/policyDefinitions/Storage/storage-account-upgrade-blobstorage-account-to-gpv2/azurepolicy.rules.json
@@ -1,0 +1,81 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Storage/storageAccounts"
+      },
+      {
+        "field": "kind",
+        "equals": "BlobStorage"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[field('name')]",
+      "existenceCondition": {
+        "field": "kind",
+        "equals": "StorageV2"
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab"
+      ],
+      "deploymentScope": "resourceGroup",
+      "deployment": {
+        "properties": {
+          "mode": "Incremental",
+          "parameters": {
+            "storageAccountName": {
+              "value": "[field('name')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            },
+            "skuName": {
+              "value": "[field('Microsoft.Storage/storageAccounts/sku.name')]"
+            },
+            "accessTier": {
+              "value": "[field('Microsoft.Storage/storageAccounts/accessTier')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "storageAccountName": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              },
+              "skuName": {
+                "type": "string"
+              },
+              "accessTier": {
+                "type": "string"
+              }
+            },
+            "resources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts",
+                "apiVersion": "2023-01-01",
+                "name": "[parameters('storageAccountName')]",
+                "location": "[parameters('location')]",
+                "sku": {
+                  "name": "[parameters('skuName')]"
+                },
+                "kind": "StorageV2",
+                "properties": {
+                  "accessTier": "[parameters('accessTier')]"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/Storage/storage-account-upgrade-gpv1-storage-account-to-gpv2/azurepolicy.json
+++ b/policyDefinitions/Storage/storage-account-upgrade-gpv1-storage-account-to-gpv2/azurepolicy.json
@@ -1,0 +1,98 @@
+{
+  "name": "45b0c7e7-c546-4aa4-94ec-188951feecc6",
+  "mode": "Indexed",
+  "displayName": "Upgrade GPv1 storage accounts to GPv2",
+  "description": "Audits or upgrades legacy General Purpose v1 (GPv1) storage accounts to General Purpose v2 (GPv2) while preserving the existing storage account redundancy SKU.",
+  "metadata": {
+    "category": "Storage",
+    "version": "1.0.0"
+  },
+  "parameters": {
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Audit or automatically upgrade GPv1 storage accounts to GPv2."
+      },
+      "allowedValues": [
+        "AuditIfNotExists",
+        "DeployIfNotExists",
+        "Disabled"
+      ],
+      "defaultValue": "AuditIfNotExists"
+    }
+  },
+  "policyRule": {
+    "if": {
+      "allOf": [
+        {
+          "field": "type",
+          "equals": "Microsoft.Storage/storageAccounts"
+        },
+        {
+          "field": "kind",
+          "equals": "Storage"
+        }
+      ]
+    },
+    "then": {
+      "effect": "[parameters('effect')]",
+      "details": {
+        "type": "Microsoft.Storage/storageAccounts",
+        "name": "[field('name')]",
+        "existenceCondition": {
+          "field": "kind",
+          "equals": "StorageV2"
+        },
+        "roleDefinitionIds": [
+          "/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab"
+        ],
+        "deploymentScope": "resourceGroup",
+        "deployment": {
+          "properties": {
+            "mode": "Incremental",
+            "parameters": {
+              "storageAccountName": {
+                "value": "[field('name')]"
+              },
+              "location": {
+                "value": "[field('location')]"
+              },
+              "skuName": {
+                "value": "[field('Microsoft.Storage/storageAccounts/sku.name')]"
+              }
+            },
+            "template": {
+              "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "parameters": {
+                "storageAccountName": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                },
+                "skuName": {
+                  "type": "string"
+                }
+              },
+              "resources": [
+                {
+                  "type": "Microsoft.Storage/storageAccounts",
+                  "apiVersion": "2023-01-01",
+                  "name": "[parameters('storageAccountName')]",
+                  "location": "[parameters('location')]",
+                  "sku": {
+                    "name": "[parameters('skuName')]"
+                  },
+                  "kind": "StorageV2",
+                  "properties": {}
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/policyDefinitions/Storage/storage-account-upgrade-gpv1-storage-account-to-gpv2/azurepolicy.parameters.json
+++ b/policyDefinitions/Storage/storage-account-upgrade-gpv1-storage-account-to-gpv2/azurepolicy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "effect": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Effect",
+      "description": "Audit or automatically upgrade GPv1 storage accounts to GPv2."
+    },
+    "allowedValues": [
+      "AuditIfNotExists",
+      "DeployIfNotExists",
+      "Disabled"
+    ],
+    "defaultValue": "AuditIfNotExists"
+  }
+}

--- a/policyDefinitions/Storage/storage-account-upgrade-gpv1-storage-account-to-gpv2/azurepolicy.rules.json
+++ b/policyDefinitions/Storage/storage-account-upgrade-gpv1-storage-account-to-gpv2/azurepolicy.rules.json
@@ -1,0 +1,73 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.Storage/storageAccounts"
+      },
+      {
+        "field": "kind",
+        "equals": "Storage"
+      }
+    ]
+  },
+  "then": {
+    "effect": "[parameters('effect')]",
+    "details": {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[field('name')]",
+      "existenceCondition": {
+        "field": "kind",
+        "equals": "StorageV2"
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab"
+      ],
+      "deploymentScope": "resourceGroup",
+      "deployment": {
+        "properties": {
+          "mode": "Incremental",
+          "parameters": {
+            "storageAccountName": {
+              "value": "[field('name')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            },
+            "skuName": {
+              "value": "[field('Microsoft.Storage/storageAccounts/sku.name')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "storageAccountName": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              },
+              "skuName": {
+                "type": "string"
+              }
+            },
+            "resources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts",
+                "apiVersion": "2023-01-01",
+                "name": "[parameters('storageAccountName')]",
+                "location": "[parameters('location')]",
+                "sku": {
+                  "name": "[parameters('skuName')]"
+                },
+                "kind": "StorageV2",
+                "properties": {}
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This contribution adds a Storage policy that identifies legacy BlobStorage accounts and optionally upgrades them to StorageV2 using DeployIfNotExists remediation.

The policy preserves the existing storage account SKU and access tier during remediation and supports AuditIfNotExists, DeployIfNotExists, and Disabled effects.

Tested successfully in a sandbox subscription using Azure Policy remediation.