### PR TITLE
Improve Tags/deny-resource-without-tag: add empty-value check, excludedResourceTypes param, and description

### DIFF
--- a/policyDefinitions/Tags/deny-resource-without-tag/azurepolicy.json
+++ b/policyDefinitions/Tags/deny-resource-without-tag/azurepolicy.json
@@ -3,9 +3,9 @@
   "type": "Microsoft.Authorization/policyDefinitions",
   "properties": {
     "displayName": "Deny-resource-without-tag",
-    "description": "need to add description",
+    "description": "Requires that a specified tag exists and is not empty on resources. Resource types that do not support tags can be excluded via the excludedResourceTypes parameter. Does not apply to resource groups (mode Indexed).",
     "metadata": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "category": "Tags"
     },
     "mode": "Indexed",
@@ -14,8 +14,17 @@
         "type": "String",
         "metadata": {
           "displayName": "Tag name",
-          "description": "Name of the tag to enforce"
+          "description": "Name of the tag to enforce, such as 'Environment' or 'CostCenter'."
         }
+      },
+      "excludedResourceTypes": {
+        "type": "Array",
+        "metadata": {
+          "displayName": "Excluded Resource Types",
+          "description": "Resource types to exclude from this policy. Useful for resource types that do not support tags.",
+          "strongType": "ResourceType"
+        },
+        "defaultValue": []
       },
       "effect": {
         "type": "String",
@@ -33,10 +42,22 @@
     },
     "policyRule": {
       "if": {
-        "allof": [
+        "allOf": [
           {
-            "field": "[concat('tags[', parameters('tagName'), ']')]",
-            "exists": "false"
+            "field": "type",
+            "notIn": "[parameters('excludedResourceTypes')]"
+          },
+          {
+            "anyOf": [
+              {
+                "field": "[concat('tags[', parameters('tagName'), ']')]",
+                "exists": "false"
+              },
+              {
+                "field": "[concat('tags[', parameters('tagName'), ']')]",
+                "equals": ""
+              }
+            ]
           }
         ]
       },

--- a/policyDefinitions/Tags/deny-resource-without-tag/azurepolicy.json
+++ b/policyDefinitions/Tags/deny-resource-without-tag/azurepolicy.json
@@ -22,7 +22,7 @@
         "metadata": {
           "displayName": "Excluded Resource Types",
           "description": "Resource types to exclude from this policy. Useful for resource types that do not support tags.",
-          "strongType": "ResourceType"
+          "strongType": "resourceTypes"
         },
         "defaultValue": []
       },

--- a/policyDefinitions/Tags/deny-resource-without-tag/azurepolicy.parameters.json
+++ b/policyDefinitions/Tags/deny-resource-without-tag/azurepolicy.parameters.json
@@ -3,8 +3,17 @@
     "type": "String",
     "metadata": {
       "displayName": "Tag name",
-      "description": "Name of the tag to enforce"
+      "description": "Name of the tag to enforce, such as 'Environment' or 'CostCenter'."
     }
+  },
+  "excludedResourceTypes": {
+    "type": "Array",
+    "metadata": {
+      "displayName": "Excluded Resource Types",
+      "description": "Resource types to exclude from this policy. Useful for resource types that do not support tags.",
+      "strongType": "ResourceType"
+    },
+    "defaultValue": []
   },
   "effect": {
     "type": "String",

--- a/policyDefinitions/Tags/deny-resource-without-tag/azurepolicy.rules.json
+++ b/policyDefinitions/Tags/deny-resource-without-tag/azurepolicy.rules.json
@@ -1,9 +1,21 @@
 {
   "if": {
-    "allof": [
+    "allOf": [
       {
-        "field": "[concat('tags[', parameters('tagName'), ']')]",
-        "exists": "false"
+        "field": "type",
+        "notIn": "[parameters('excludedResourceTypes')]"
+      },
+      {
+        "anyOf": [
+          {
+            "field": "[concat('tags[', parameters('tagName'), ']')]",
+            "exists": "false"
+          },
+          {
+            "field": "[concat('tags[', parameters('tagName'), ']')]",
+            "equals": ""
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

Improves the existing **`Tags/deny-resource-without-tag`** policy definition. This is an in-place update (same policy `name` GUID `12dc4dea-6097-4a18-b24e-a9a3e00dd456`), not a new policy, so existing assignments continue to work.

## What changed

- **Description**: replaced the placeholder `"need to add description"` with a meaningful description of the policy behavior.
- **Empty-value detection**: the rule now triggers when the tag exists but is **empty** (`equals ""`), in addition to the previous "tag does not exist" check. Previously a resource with an empty tag value passed compliance.
- **New `excludedResourceTypes` parameter** (`Array`, `strongType: ResourceType`, default `[]`): allows excluding resource types that don't support tags, without editing the policy. More flexible than hardcoding exclusions.
- **Fixed `allof` → `allOf`** casing in the policy rule.
- **Version bumped** `1.0.0` → `1.1.0` (added functionality, backward compatible — the new parameter defaults to an empty array).

## Backward compatibility

- Same policy GUID → updates the existing definition rather than creating a new one.
- The new `excludedResourceTypes` parameter has a default value (`[]`), so existing assignments are unaffected.
- The `effect` default remains `Audit`.

## Validation

Validated with the repository's own script:

